### PR TITLE
feat: add PropertyGrid control (#11)

### DIFF
--- a/src/MauiControlsExtras/Controls/PropertyGrid/IPropertyEditor.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/IPropertyEditor.cs
@@ -1,0 +1,41 @@
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// Interface for custom property editors in the PropertyGrid.
+/// </summary>
+public interface IPropertyEditor
+{
+    /// <summary>
+    /// Creates the editor view for a property.
+    /// </summary>
+    /// <param name="property">The property item to edit.</param>
+    /// <returns>The editor view.</returns>
+    View CreateEditor(PropertyItem property);
+
+    /// <summary>
+    /// Gets whether this editor supports the specified property type.
+    /// </summary>
+    /// <param name="propertyType">The property type.</param>
+    /// <returns>True if supported, false otherwise.</returns>
+    bool SupportsType(Type propertyType);
+}
+
+/// <summary>
+/// Base implementation of IPropertyEditor.
+/// </summary>
+public abstract class PropertyEditorBase : IPropertyEditor
+{
+    /// <inheritdoc/>
+    public abstract View CreateEditor(PropertyItem property);
+
+    /// <inheritdoc/>
+    public abstract bool SupportsType(Type propertyType);
+
+    /// <summary>
+    /// Creates a binding to the property value.
+    /// </summary>
+    protected Binding CreateValueBinding(PropertyItem property, BindingMode mode = BindingMode.TwoWay)
+    {
+        return new Binding(nameof(PropertyItem.Value), mode, source: property);
+    }
+}

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyCategory.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyCategory.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// Represents a category of properties in the PropertyGrid.
+/// </summary>
+public class PropertyCategory : INotifyPropertyChanged
+{
+    private bool _isExpanded = true;
+
+    /// <summary>
+    /// Gets the category name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the properties in this category.
+    /// </summary>
+    public IReadOnlyList<PropertyItem> Properties { get; }
+
+    /// <summary>
+    /// Gets or sets whether this category is expanded.
+    /// </summary>
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set
+        {
+            if (_isExpanded != value)
+            {
+                _isExpanded = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExpanded)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of properties in this category.
+    /// </summary>
+    public int PropertyCount => Properties.Count;
+
+    /// <summary>
+    /// Gets the icon for expand/collapse.
+    /// </summary>
+    public string ExpanderIcon => IsExpanded ? "▼" : "▶";
+
+    /// <summary>
+    /// Occurs when a property changes.
+    /// </summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyCategory"/> class.
+    /// </summary>
+    public PropertyCategory(string name, IReadOnlyList<PropertyItem> properties)
+    {
+        Name = name;
+        Properties = properties;
+    }
+
+    /// <summary>
+    /// Toggles the expanded state.
+    /// </summary>
+    public void ToggleExpanded()
+    {
+        IsExpanded = !IsExpanded;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ExpanderIcon)));
+    }
+}

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<base:HeaderedControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                          xmlns:base="clr-namespace:MauiControlsExtras.Base"
+                          xmlns:local="clr-namespace:MauiControlsExtras.Controls"
+                          x:Class="MauiControlsExtras.Controls.PropertyGrid"
+                          x:Name="thisControl">
+
+    <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
+            Stroke="{Binding EffectiveBorderColor, Source={x:Reference thisControl}}"
+            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1E1E1E}">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="{Binding EffectiveCornerRadius, Source={x:Reference thisControl}}" />
+        </Border.StrokeShape>
+
+        <Grid RowDefinitions="Auto,*,Auto">
+            <!-- Search Box -->
+            <Border Grid.Row="0"
+                    IsVisible="{Binding ShowSearchBox, Source={x:Reference thisControl}}"
+                    BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#2D2D2D}"
+                    Padding="8">
+                <Grid ColumnDefinitions="*,Auto">
+                    <Entry x:Name="searchEntry"
+                           Placeholder="Search properties..."
+                           Text="{Binding SearchText, Source={x:Reference thisControl}, Mode=TwoWay}"
+                           TextChanged="OnSearchTextChanged"
+                           BackgroundColor="Transparent" />
+                    <Button Grid.Column="1"
+                            Text="✕"
+                            WidthRequest="32"
+                            HeightRequest="32"
+                            Padding="0"
+                            BackgroundColor="Transparent"
+                            IsVisible="{Binding HasSearchText, Source={x:Reference thisControl}}"
+                            Clicked="OnClearSearchClicked" />
+                </Grid>
+            </Border>
+
+            <!-- Properties List -->
+            <ScrollView Grid.Row="1"
+                        Orientation="Vertical"
+                        VerticalScrollBarVisibility="Auto">
+                <VerticalStackLayout x:Name="propertiesContainer"
+                                     Spacing="0">
+                    <!-- Properties are added dynamically -->
+                </VerticalStackLayout>
+            </ScrollView>
+
+            <!-- Description Panel -->
+            <Border Grid.Row="2"
+                    IsVisible="{Binding ShowDescription, Source={x:Reference thisControl}}"
+                    BackgroundColor="{AppThemeBinding Light=#F9F9F9, Dark=#252525}"
+                    Padding="12"
+                    MinimumHeightRequest="60">
+                <VerticalStackLayout Spacing="4">
+                    <Label x:Name="descriptionTitle"
+                           FontAttributes="Bold"
+                           FontSize="13"
+                           TextColor="{Binding EffectiveForegroundColor, Source={x:Reference thisControl}}" />
+                    <Label x:Name="descriptionText"
+                           FontSize="12"
+                           LineBreakMode="WordWrap"
+                           TextColor="{AppThemeBinding Light=#666666, Dark=#AAAAAA}" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Empty View -->
+            <Label Grid.Row="1"
+                   x:Name="emptyLabel"
+                   IsVisible="False"
+                   Text="No object selected"
+                   HorizontalOptions="Center"
+                   VerticalOptions="Center"
+                   TextColor="{AppThemeBinding Light=#999999, Dark=#666666}" />
+        </Grid>
+    </Border>
+</base:HeaderedControlBase>

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml.cs
@@ -1,0 +1,1103 @@
+using System.ComponentModel;
+using System.Reflection;
+using System.Windows.Input;
+using MauiControlsExtras.Base;
+using MauiControlsExtras.Theming;
+
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// A PropertyGrid control that automatically generates an editable UI from an object's properties.
+/// Similar to WinForms PropertyGrid or Visual Studio's Properties panel.
+/// </summary>
+public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
+{
+    #region Private Fields
+
+    private readonly List<PropertyCategory> _categories = new();
+    private readonly List<PropertyItem> _flatProperties = new();
+    private PropertyItem? _selectedProperty;
+    private bool _hasKeyboardFocus;
+
+    #endregion
+
+    #region Bindable Properties
+
+    /// <summary>
+    /// Identifies the <see cref="SelectedObject"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectedObjectProperty = BindableProperty.Create(
+        nameof(SelectedObject),
+        typeof(object),
+        typeof(PropertyGrid),
+        null,
+        BindingMode.TwoWay,
+        propertyChanged: OnSelectedObjectChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="IsReadOnly"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(
+        nameof(IsReadOnly),
+        typeof(bool),
+        typeof(PropertyGrid),
+        false,
+        propertyChanged: OnIsReadOnlyChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="ShowCategories"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ShowCategoriesProperty = BindableProperty.Create(
+        nameof(ShowCategories),
+        typeof(bool),
+        typeof(PropertyGrid),
+        true,
+        propertyChanged: OnShowCategoriesChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="ShowDescription"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ShowDescriptionProperty = BindableProperty.Create(
+        nameof(ShowDescription),
+        typeof(bool),
+        typeof(PropertyGrid),
+        true);
+
+    /// <summary>
+    /// Identifies the <see cref="ShowSearchBox"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ShowSearchBoxProperty = BindableProperty.Create(
+        nameof(ShowSearchBox),
+        typeof(bool),
+        typeof(PropertyGrid),
+        true);
+
+    /// <summary>
+    /// Identifies the <see cref="SortMode"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SortModeProperty = BindableProperty.Create(
+        nameof(SortMode),
+        typeof(PropertySortMode),
+        typeof(PropertyGrid),
+        PropertySortMode.Categorized,
+        propertyChanged: OnSortModeChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="ExpandAllCategories"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ExpandAllCategoriesProperty = BindableProperty.Create(
+        nameof(ExpandAllCategories),
+        typeof(bool),
+        typeof(PropertyGrid),
+        false);
+
+    /// <summary>
+    /// Identifies the <see cref="SearchText"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SearchTextProperty = BindableProperty.Create(
+        nameof(SearchText),
+        typeof(string),
+        typeof(PropertyGrid),
+        null,
+        propertyChanged: OnSearchTextChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="IsKeyboardNavigationEnabled"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty IsKeyboardNavigationEnabledProperty = BindableProperty.Create(
+        nameof(IsKeyboardNavigationEnabled),
+        typeof(bool),
+        typeof(PropertyGrid),
+        true);
+
+    #endregion
+
+    #region Command Properties
+
+    /// <summary>
+    /// Identifies the <see cref="PropertyChangedCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PropertyChangedCommandProperty = BindableProperty.Create(
+        nameof(PropertyChangedCommand),
+        typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectedObjectChangedCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectedObjectChangedCommandProperty = BindableProperty.Create(
+        nameof(SelectedObjectChangedCommand),
+        typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="PropertySelectionChangedCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PropertySelectionChangedCommandProperty = BindableProperty.Create(
+        nameof(PropertySelectionChangedCommand),
+        typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="GotFocusCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandProperty = BindableProperty.Create(
+        nameof(GotFocusCommand),
+        typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="LostFocusCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandProperty = BindableProperty.Create(
+        nameof(LostFocusCommand),
+        typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="KeyPressCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandProperty = BindableProperty.Create(
+        nameof(KeyPressCommand),
+        typeof(ICommand),
+        typeof(PropertyGrid));
+
+    #endregion
+
+    #region Properties
+
+    /// <summary>
+    /// Gets or sets the object to edit.
+    /// </summary>
+    public object? SelectedObject
+    {
+        get => GetValue(SelectedObjectProperty);
+        set => SetValue(SelectedObjectProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the property grid is read-only.
+    /// </summary>
+    public bool IsReadOnly
+    {
+        get => (bool)GetValue(IsReadOnlyProperty);
+        set => SetValue(IsReadOnlyProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether properties are grouped by category.
+    /// </summary>
+    public bool ShowCategories
+    {
+        get => (bool)GetValue(ShowCategoriesProperty);
+        set => SetValue(ShowCategoriesProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the description panel is shown.
+    /// </summary>
+    public bool ShowDescription
+    {
+        get => (bool)GetValue(ShowDescriptionProperty);
+        set => SetValue(ShowDescriptionProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the search box is shown.
+    /// </summary>
+    public bool ShowSearchBox
+    {
+        get => (bool)GetValue(ShowSearchBoxProperty);
+        set => SetValue(ShowSearchBoxProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the property sort mode.
+    /// </summary>
+    public PropertySortMode SortMode
+    {
+        get => (PropertySortMode)GetValue(SortModeProperty);
+        set => SetValue(SortModeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether all categories start expanded.
+    /// </summary>
+    public bool ExpandAllCategories
+    {
+        get => (bool)GetValue(ExpandAllCategoriesProperty);
+        set => SetValue(ExpandAllCategoriesProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the search filter text.
+    /// </summary>
+    public string? SearchText
+    {
+        get => (string?)GetValue(SearchTextProperty);
+        set => SetValue(SearchTextProperty, value);
+    }
+
+    /// <summary>
+    /// Gets whether there is search text.
+    /// </summary>
+    public bool HasSearchText => !string.IsNullOrEmpty(SearchText);
+
+    /// <summary>
+    /// Gets the property categories.
+    /// </summary>
+    public IReadOnlyList<PropertyCategory> Categories => _categories;
+
+    /// <summary>
+    /// Gets the currently selected property.
+    /// </summary>
+    public PropertyItem? SelectedProperty => _selectedProperty;
+
+    #endregion
+
+    #region Command Properties Implementation
+
+    /// <summary>
+    /// Gets or sets the command executed when a property value changes.
+    /// </summary>
+    public ICommand? PropertyChangedCommand
+    {
+        get => (ICommand?)GetValue(PropertyChangedCommandProperty);
+        set => SetValue(PropertyChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command executed when the selected object changes.
+    /// </summary>
+    public ICommand? SelectedObjectChangedCommand
+    {
+        get => (ICommand?)GetValue(SelectedObjectChangedCommandProperty);
+        set => SetValue(SelectedObjectChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command executed when property selection changes.
+    /// </summary>
+    public ICommand? PropertySelectionChangedCommand
+    {
+        get => (ICommand?)GetValue(PropertySelectionChangedCommandProperty);
+        set => SetValue(PropertySelectionChangedCommandProperty, value);
+    }
+
+    /// <inheritdoc/>
+    public ICommand? GotFocusCommand
+    {
+        get => (ICommand?)GetValue(GotFocusCommandProperty);
+        set => SetValue(GotFocusCommandProperty, value);
+    }
+
+    /// <inheritdoc/>
+    public ICommand? LostFocusCommand
+    {
+        get => (ICommand?)GetValue(LostFocusCommandProperty);
+        set => SetValue(LostFocusCommandProperty, value);
+    }
+
+    /// <inheritdoc/>
+    public ICommand? KeyPressCommand
+    {
+        get => (ICommand?)GetValue(KeyPressCommandProperty);
+        set => SetValue(KeyPressCommandProperty, value);
+    }
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Occurs when a property value changes.
+    /// </summary>
+    public event EventHandler<PropertyValueChangedEventArgs>? PropertyValueChanged;
+
+    /// <summary>
+    /// Occurs before a property value changes (cancelable).
+    /// </summary>
+#pragma warning disable CS0067
+    public event EventHandler<PropertyValueChangingEventArgs>? PropertyValueChanging;
+#pragma warning restore CS0067
+
+    /// <summary>
+    /// Occurs when the selected object changes.
+    /// </summary>
+    public event EventHandler<SelectedObjectChangedEventArgs>? SelectedObjectChanged;
+
+    /// <summary>
+    /// Occurs when the property selection changes.
+    /// </summary>
+    public event EventHandler<PropertySelectionChangedEventArgs>? PropertySelectionChanged;
+
+    /// <inheritdoc/>
+    public event EventHandler<KeyboardFocusEventArgs>? KeyboardFocusGained;
+
+    /// <inheritdoc/>
+#pragma warning disable CS0067
+    public event EventHandler<KeyboardFocusEventArgs>? KeyboardFocusLost;
+#pragma warning restore CS0067
+
+    /// <inheritdoc/>
+    public event EventHandler<KeyEventArgs>? KeyPressed;
+
+    /// <inheritdoc/>
+#pragma warning disable CS0067
+    public event EventHandler<KeyEventArgs>? KeyReleased;
+#pragma warning restore CS0067
+
+    #endregion
+
+    #region IKeyboardNavigable Implementation
+
+    /// <inheritdoc/>
+    public bool CanReceiveFocus => IsEnabled && IsVisible;
+
+    /// <inheritdoc/>
+    public bool IsKeyboardNavigationEnabled
+    {
+        get => (bool)GetValue(IsKeyboardNavigationEnabledProperty);
+        set => SetValue(IsKeyboardNavigationEnabledProperty, value);
+    }
+
+    /// <inheritdoc/>
+    public bool HasKeyboardFocus => _hasKeyboardFocus;
+
+    /// <inheritdoc/>
+    public bool HandleKeyPress(KeyEventArgs e)
+    {
+        if (!IsKeyboardNavigationEnabled) return false;
+
+        KeyPressed?.Invoke(this, e);
+        if (e.Handled) return true;
+
+        if (KeyPressCommand?.CanExecute(e) == true)
+        {
+            KeyPressCommand.Execute(e);
+            if (e.Handled) return true;
+        }
+
+        switch (e.Key)
+        {
+            case "ArrowUp":
+                SelectPreviousProperty();
+                return true;
+            case "ArrowDown":
+                SelectNextProperty();
+                return true;
+            case "ArrowLeft":
+                if (_selectedProperty?.IsExpandable == true && _selectedProperty.IsExpanded)
+                {
+                    _selectedProperty.IsExpanded = false;
+                    RefreshUI();
+                    return true;
+                }
+                break;
+            case "ArrowRight":
+                if (_selectedProperty?.IsExpandable == true && !_selectedProperty.IsExpanded)
+                {
+                    _selectedProperty.IsExpanded = true;
+                    RefreshUI();
+                    return true;
+                }
+                break;
+            case "Home":
+                if (_flatProperties.Count > 0)
+                {
+                    SelectProperty(_flatProperties[0]);
+                    return true;
+                }
+                break;
+            case "End":
+                if (_flatProperties.Count > 0)
+                {
+                    SelectProperty(_flatProperties[^1]);
+                    return true;
+                }
+                break;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<KeyboardShortcut> GetKeyboardShortcuts()
+    {
+        return new List<KeyboardShortcut>
+        {
+            new() { Key = "ArrowUp", Description = "Select previous property", Category = "Navigation" },
+            new() { Key = "ArrowDown", Description = "Select next property", Category = "Navigation" },
+            new() { Key = "ArrowLeft", Description = "Collapse property", Category = "Navigation" },
+            new() { Key = "ArrowRight", Description = "Expand property", Category = "Navigation" },
+            new() { Key = "Home", Description = "Select first property", Category = "Navigation" },
+            new() { Key = "End", Description = "Select last property", Category = "Navigation" }
+        };
+    }
+
+    /// <inheritdoc/>
+    public new bool Focus()
+    {
+        if (!CanReceiveFocus) return false;
+        _hasKeyboardFocus = true;
+        OnPropertyChanged(nameof(HasKeyboardFocus));
+        KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
+        GotFocusCommand?.Execute(this);
+        return true;
+    }
+
+    #endregion
+
+    #region Constructor
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyGrid"/> class.
+    /// </summary>
+    public PropertyGrid()
+    {
+        InitializeComponent();
+    }
+
+    #endregion
+
+    #region Property Discovery
+
+    private void DiscoverProperties()
+    {
+        _categories.Clear();
+        _flatProperties.Clear();
+
+        if (SelectedObject == null)
+        {
+            emptyLabel.IsVisible = true;
+            propertiesContainer.IsVisible = false;
+            return;
+        }
+
+        emptyLabel.IsVisible = false;
+        propertiesContainer.IsVisible = true;
+
+        var type = SelectedObject.GetType();
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetCustomAttribute<BrowsableAttribute>()?.Browsable != false)
+            .Select(p => new PropertyItem(p, SelectedObject))
+            .ToList();
+
+        // Filter by search text
+        if (!string.IsNullOrWhiteSpace(SearchText))
+        {
+            var search = SearchText.ToLowerInvariant();
+            properties = properties
+                .Where(p => p.DisplayName.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                            p.Name.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                            (p.Description?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false))
+                .ToList();
+        }
+
+        // Sort properties
+        properties = SortMode switch
+        {
+            PropertySortMode.Alphabetical => properties.OrderBy(p => p.DisplayName).ToList(),
+            PropertySortMode.Categorized => properties.OrderBy(p => p.Category).ThenBy(p => p.DisplayName).ToList(),
+            _ => properties
+        };
+
+        _flatProperties.AddRange(properties);
+
+        // Group by category
+        if (ShowCategories && SortMode == PropertySortMode.Categorized)
+        {
+            var groups = properties.GroupBy(p => p.Category);
+            foreach (var group in groups)
+            {
+                var category = new PropertyCategory(group.Key, group.ToList());
+                category.IsExpanded = ExpandAllCategories || _categories.Count == 0;
+                _categories.Add(category);
+            }
+        }
+        else
+        {
+            // Single "All Properties" category
+            var category = new PropertyCategory("All Properties", properties);
+            category.IsExpanded = true;
+            _categories.Add(category);
+        }
+
+        // Subscribe to property changes
+        foreach (var prop in _flatProperties)
+        {
+            prop.ValueChanged += OnPropertyValueChanged;
+        }
+
+        RefreshUI();
+    }
+
+    #endregion
+
+    #region UI Building
+
+    private void RefreshUI()
+    {
+        propertiesContainer.Children.Clear();
+
+        foreach (var category in _categories)
+        {
+            if (ShowCategories && SortMode == PropertySortMode.Categorized)
+            {
+                // Add category header
+                var categoryHeader = CreateCategoryHeader(category);
+                propertiesContainer.Children.Add(categoryHeader);
+            }
+
+            if (!ShowCategories || SortMode != PropertySortMode.Categorized || category.IsExpanded)
+            {
+                foreach (var property in category.Properties)
+                {
+                    var propertyRow = CreatePropertyRow(property);
+                    propertiesContainer.Children.Add(propertyRow);
+                }
+            }
+        }
+    }
+
+    private View CreateCategoryHeader(PropertyCategory category)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitionCollection
+            {
+                new ColumnDefinition(GridLength.Auto),
+                new ColumnDefinition(GridLength.Star)
+            },
+            Padding = new Thickness(8, 6),
+            BackgroundColor = EffectiveHeaderBackgroundColor
+        };
+
+        var expander = new Label
+        {
+            Text = category.ExpanderIcon,
+            FontSize = 10,
+            VerticalOptions = LayoutOptions.Center,
+            TextColor = EffectiveForegroundColor
+        };
+
+        var title = new Label
+        {
+            Text = category.Name,
+            FontAttributes = HeaderFontAttributes,
+            FontSize = HeaderFontSize,
+            VerticalOptions = LayoutOptions.Center,
+            Margin = new Thickness(8, 0, 0, 0),
+            TextColor = EffectiveHeaderTextColor
+        };
+
+        grid.Add(expander, 0, 0);
+        grid.Add(title, 1, 0);
+
+        var tapGesture = new TapGestureRecognizer();
+        tapGesture.Tapped += (s, e) =>
+        {
+            category.ToggleExpanded();
+            expander.Text = category.ExpanderIcon;
+            RefreshUI();
+        };
+        grid.GestureRecognizers.Add(tapGesture);
+
+        return grid;
+    }
+
+    private View CreatePropertyRow(PropertyItem property)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitionCollection
+            {
+                new ColumnDefinition(new GridLength(0.4, GridUnitType.Star)),
+                new ColumnDefinition(new GridLength(0.6, GridUnitType.Star))
+            },
+            Padding = new Thickness(12, 6),
+            BackgroundColor = property.IsSelected
+                ? MauiControlsExtrasTheme.Current.SelectedBackgroundColor
+                : Colors.Transparent
+        };
+
+        // Property name
+        var nameLabel = new Label
+        {
+            Text = property.DisplayName,
+            FontSize = 13,
+            VerticalOptions = LayoutOptions.Center,
+            TextColor = property.IsReadOnly || IsReadOnly
+                ? EffectiveDisabledColor
+                : EffectiveForegroundColor
+        };
+        grid.Add(nameLabel, 0, 0);
+
+        // Property editor
+        var editor = CreateEditor(property);
+        editor.VerticalOptions = LayoutOptions.Center;
+        grid.Add(editor, 1, 0);
+
+        // Selection handling
+        var tapGesture = new TapGestureRecognizer();
+        tapGesture.Tapped += (s, e) => SelectProperty(property);
+        grid.GestureRecognizers.Add(tapGesture);
+
+        // Add separator
+        var container = new VerticalStackLayout { Spacing = 0 };
+        container.Children.Add(grid);
+        container.Children.Add(new BoxView
+        {
+            HeightRequest = 1,
+            BackgroundColor = MauiControlsExtrasTheme.GetBorderColor(),
+            Opacity = 0.3
+        });
+
+        return container;
+    }
+
+    private View CreateEditor(PropertyItem property)
+    {
+        var isReadOnly = property.IsReadOnly || IsReadOnly;
+        var type = property.PropertyType;
+
+        // Custom editor
+        if (property.EditorType != null)
+        {
+            var customEditor = Activator.CreateInstance(property.EditorType) as IPropertyEditor;
+            if (customEditor != null)
+            {
+                return customEditor.CreateEditor(property);
+            }
+        }
+
+        // Built-in editors
+        if (type == typeof(bool))
+        {
+            return CreateBoolEditor(property, isReadOnly);
+        }
+
+        if (type == typeof(string))
+        {
+            return CreateStringEditor(property, isReadOnly);
+        }
+
+        if (type == typeof(int) || type == typeof(long) || type == typeof(short) || type == typeof(byte))
+        {
+            return CreateIntEditor(property, isReadOnly);
+        }
+
+        if (type == typeof(double) || type == typeof(float) || type == typeof(decimal))
+        {
+            return CreateDoubleEditor(property, isReadOnly);
+        }
+
+        if (type == typeof(DateTime))
+        {
+            return CreateDateTimeEditor(property, isReadOnly);
+        }
+
+        if (type == typeof(TimeSpan))
+        {
+            return CreateTimeSpanEditor(property, isReadOnly);
+        }
+
+        if (type == typeof(Color))
+        {
+            return CreateColorEditor(property, isReadOnly);
+        }
+
+        if (type.IsEnum)
+        {
+            return CreateEnumEditor(property, isReadOnly);
+        }
+
+        // Default: read-only text
+        return new Label
+        {
+            Text = property.DisplayValue,
+            FontSize = 13,
+            TextColor = EffectiveForegroundColor
+        };
+    }
+
+    private View CreateBoolEditor(PropertyItem property, bool isReadOnly)
+    {
+        var toggle = new Switch
+        {
+            IsToggled = property.Value is true,
+            IsEnabled = !isReadOnly
+        };
+        toggle.Toggled += (s, e) => property.Value = e.Value;
+        property.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.Value))
+            {
+                toggle.IsToggled = property.Value is true;
+            }
+        };
+        return toggle;
+    }
+
+    private View CreateStringEditor(PropertyItem property, bool isReadOnly)
+    {
+        var entry = new Entry
+        {
+            Text = property.Value?.ToString() ?? "",
+            IsReadOnly = isReadOnly,
+            BackgroundColor = Colors.Transparent
+        };
+        entry.TextChanged += (s, e) => property.Value = e.NewTextValue;
+        property.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.Value))
+            {
+                entry.Text = property.Value?.ToString() ?? "";
+            }
+        };
+        return entry;
+    }
+
+    private View CreateIntEditor(PropertyItem property, bool isReadOnly)
+    {
+        var entry = new Entry
+        {
+            Text = property.Value?.ToString() ?? "",
+            Keyboard = Keyboard.Numeric,
+            IsReadOnly = isReadOnly,
+            BackgroundColor = Colors.Transparent
+        };
+        entry.Unfocused += (s, e) =>
+        {
+            if (int.TryParse(entry.Text, out var value))
+            {
+                // Apply range if specified
+                if (property.Minimum != null && value < Convert.ToInt32(property.Minimum))
+                    value = Convert.ToInt32(property.Minimum);
+                if (property.Maximum != null && value > Convert.ToInt32(property.Maximum))
+                    value = Convert.ToInt32(property.Maximum);
+                property.Value = value;
+            }
+        };
+        property.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.Value))
+            {
+                entry.Text = property.Value?.ToString() ?? "";
+            }
+        };
+        return entry;
+    }
+
+    private View CreateDoubleEditor(PropertyItem property, bool isReadOnly)
+    {
+        var entry = new Entry
+        {
+            Text = property.Value?.ToString() ?? "",
+            Keyboard = Keyboard.Numeric,
+            IsReadOnly = isReadOnly,
+            BackgroundColor = Colors.Transparent
+        };
+        entry.Unfocused += (s, e) =>
+        {
+            if (double.TryParse(entry.Text, out var value))
+            {
+                // Apply range if specified
+                if (property.Minimum != null && value < Convert.ToDouble(property.Minimum))
+                    value = Convert.ToDouble(property.Minimum);
+                if (property.Maximum != null && value > Convert.ToDouble(property.Maximum))
+                    value = Convert.ToDouble(property.Maximum);
+                property.Value = value;
+            }
+        };
+        property.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.Value))
+            {
+                entry.Text = property.Value?.ToString() ?? "";
+            }
+        };
+        return entry;
+    }
+
+    private View CreateDateTimeEditor(PropertyItem property, bool isReadOnly)
+    {
+        var picker = new DatePicker
+        {
+            Date = property.Value is DateTime dt ? dt : DateTime.Today,
+            IsEnabled = !isReadOnly
+        };
+        picker.DateSelected += (s, e) => property.Value = e.NewDate;
+        property.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.Value) && property.Value is DateTime dt)
+            {
+                picker.Date = dt;
+            }
+        };
+        return picker;
+    }
+
+    private View CreateTimeSpanEditor(PropertyItem property, bool isReadOnly)
+    {
+        var picker = new TimePicker
+        {
+            Time = property.Value is TimeSpan ts ? ts : TimeSpan.Zero,
+            IsEnabled = !isReadOnly
+        };
+        picker.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(TimePicker.Time))
+            {
+                property.Value = picker.Time;
+            }
+        };
+        property.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.Value) && property.Value is TimeSpan ts)
+            {
+                picker.Time = ts;
+            }
+        };
+        return picker;
+    }
+
+    private View CreateColorEditor(PropertyItem property, bool isReadOnly)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitionCollection
+            {
+                new ColumnDefinition(GridLength.Auto),
+                new ColumnDefinition(GridLength.Star)
+            },
+            ColumnSpacing = 8
+        };
+
+        var colorBox = new BoxView
+        {
+            Color = property.Value as Color ?? Colors.Gray,
+            WidthRequest = 24,
+            HeightRequest = 24,
+            CornerRadius = 4
+        };
+
+        var entry = new Entry
+        {
+            Text = (property.Value as Color)?.ToHex() ?? "",
+            IsReadOnly = isReadOnly,
+            BackgroundColor = Colors.Transparent,
+            FontSize = 12
+        };
+        entry.Unfocused += (s, e) =>
+        {
+            if (Color.TryParse(entry.Text, out var color))
+            {
+                property.Value = color;
+            }
+        };
+
+        property.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.Value))
+            {
+                colorBox.Color = property.Value as Color ?? Colors.Gray;
+                entry.Text = (property.Value as Color)?.ToHex() ?? "";
+            }
+        };
+
+        grid.Add(colorBox, 0, 0);
+        grid.Add(entry, 1, 0);
+
+        return grid;
+    }
+
+    private View CreateEnumEditor(PropertyItem property, bool isReadOnly)
+    {
+        var values = Enum.GetValues(property.PropertyType);
+        var picker = new Picker
+        {
+            IsEnabled = !isReadOnly
+        };
+
+        foreach (var value in values)
+        {
+            picker.Items.Add(Enum.GetName(property.PropertyType, value) ?? value.ToString() ?? "");
+        }
+
+        if (property.Value != null)
+        {
+            picker.SelectedIndex = Array.IndexOf(Enum.GetValues(property.PropertyType), property.Value);
+        }
+
+        picker.SelectedIndexChanged += (s, e) =>
+        {
+            if (picker.SelectedIndex >= 0)
+            {
+                var enumValues = Enum.GetValues(property.PropertyType);
+                property.Value = enumValues.GetValue(picker.SelectedIndex);
+            }
+        };
+
+        property.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.Value) && property.Value != null)
+            {
+                picker.SelectedIndex = Array.IndexOf(Enum.GetValues(property.PropertyType), property.Value);
+            }
+        };
+
+        return picker;
+    }
+
+    #endregion
+
+    #region Selection
+
+    private void SelectProperty(PropertyItem property)
+    {
+        var oldProperty = _selectedProperty;
+        if (oldProperty != null)
+        {
+            oldProperty.IsSelected = false;
+        }
+
+        _selectedProperty = property;
+        property.IsSelected = true;
+
+        // Update description panel
+        descriptionTitle.Text = property.DisplayName;
+        descriptionText.Text = property.Description ?? $"Type: {property.TypeName}";
+
+        RefreshUI();
+
+        var args = new PropertySelectionChangedEventArgs(oldProperty, property);
+        PropertySelectionChanged?.Invoke(this, args);
+        PropertySelectionChangedCommand?.Execute(args);
+    }
+
+    private void SelectNextProperty()
+    {
+        if (_flatProperties.Count == 0) return;
+
+        var currentIndex = _selectedProperty != null ? _flatProperties.IndexOf(_selectedProperty) : -1;
+        var nextIndex = (currentIndex + 1) % _flatProperties.Count;
+        SelectProperty(_flatProperties[nextIndex]);
+    }
+
+    private void SelectPreviousProperty()
+    {
+        if (_flatProperties.Count == 0) return;
+
+        var currentIndex = _selectedProperty != null ? _flatProperties.IndexOf(_selectedProperty) : 0;
+        var prevIndex = currentIndex > 0 ? currentIndex - 1 : _flatProperties.Count - 1;
+        SelectProperty(_flatProperties[prevIndex]);
+    }
+
+    #endregion
+
+    #region Event Handlers
+
+    private void OnPropertyValueChanged(object? sender, PropertyValueChangedEventArgs e)
+    {
+        PropertyValueChanged?.Invoke(this, e);
+        PropertyChangedCommand?.Execute(e);
+    }
+
+    private void OnSearchTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasSearchText));
+        DiscoverProperties();
+    }
+
+    private void OnClearSearchClicked(object? sender, EventArgs e)
+    {
+        SearchText = null;
+    }
+
+    #endregion
+
+    #region Property Changed Handlers
+
+    private static void OnSelectedObjectChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is PropertyGrid grid)
+        {
+            var args = new SelectedObjectChangedEventArgs(oldValue, newValue);
+            grid.SelectedObjectChanged?.Invoke(grid, args);
+            grid.SelectedObjectChangedCommand?.Execute(args);
+            grid.DiscoverProperties();
+        }
+    }
+
+    private static void OnIsReadOnlyChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is PropertyGrid grid)
+        {
+            grid.RefreshUI();
+        }
+    }
+
+    private static void OnShowCategoriesChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is PropertyGrid grid)
+        {
+            grid.DiscoverProperties();
+        }
+    }
+
+    private static void OnSortModeChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is PropertyGrid grid)
+        {
+            grid.DiscoverProperties();
+        }
+    }
+
+    private static void OnSearchTextChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is PropertyGrid grid)
+        {
+            grid.OnPropertyChanged(nameof(HasSearchText));
+            grid.DiscoverProperties();
+        }
+    }
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// Refreshes the property grid from the current object.
+    /// </summary>
+    public void Refresh()
+    {
+        DiscoverProperties();
+    }
+
+    /// <summary>
+    /// Expands all categories.
+    /// </summary>
+    public void ExpandAll()
+    {
+        foreach (var category in _categories)
+        {
+            category.IsExpanded = true;
+        }
+        RefreshUI();
+    }
+
+    /// <summary>
+    /// Collapses all categories.
+    /// </summary>
+    public void CollapseAll()
+    {
+        foreach (var category in _categories)
+        {
+            category.IsExpanded = false;
+        }
+        RefreshUI();
+    }
+
+    #endregion
+}

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGridEnums.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGridEnums.cs
@@ -1,0 +1,22 @@
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// Specifies how properties are sorted in the PropertyGrid.
+/// </summary>
+public enum PropertySortMode
+{
+    /// <summary>
+    /// Properties are grouped by category.
+    /// </summary>
+    Categorized,
+
+    /// <summary>
+    /// Properties are sorted alphabetically.
+    /// </summary>
+    Alphabetical,
+
+    /// <summary>
+    /// No sorting, properties appear in declaration order.
+    /// </summary>
+    None
+}

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGridEventArgs.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGridEventArgs.cs
@@ -1,0 +1,118 @@
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// Event arguments for property value changes in the PropertyGrid.
+/// </summary>
+public class PropertyValueChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the property item that changed.
+    /// </summary>
+    public PropertyItem Property { get; }
+
+    /// <summary>
+    /// Gets the old value.
+    /// </summary>
+    public object? OldValue { get; }
+
+    /// <summary>
+    /// Gets the new value.
+    /// </summary>
+    public object? NewValue { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyValueChangedEventArgs"/> class.
+    /// </summary>
+    public PropertyValueChangedEventArgs(PropertyItem property, object? oldValue, object? newValue)
+    {
+        Property = property;
+        OldValue = oldValue;
+        NewValue = newValue;
+    }
+}
+
+/// <summary>
+/// Event arguments for property value changing (cancelable).
+/// </summary>
+public class PropertyValueChangingEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the property item that is changing.
+    /// </summary>
+    public PropertyItem Property { get; }
+
+    /// <summary>
+    /// Gets the current value.
+    /// </summary>
+    public object? CurrentValue { get; }
+
+    /// <summary>
+    /// Gets the proposed new value.
+    /// </summary>
+    public object? NewValue { get; }
+
+    /// <summary>
+    /// Gets or sets whether the change should be cancelled.
+    /// </summary>
+    public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyValueChangingEventArgs"/> class.
+    /// </summary>
+    public PropertyValueChangingEventArgs(PropertyItem property, object? currentValue, object? newValue)
+    {
+        Property = property;
+        CurrentValue = currentValue;
+        NewValue = newValue;
+    }
+}
+
+/// <summary>
+/// Event arguments for selected object changes.
+/// </summary>
+public class SelectedObjectChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the old selected object.
+    /// </summary>
+    public object? OldObject { get; }
+
+    /// <summary>
+    /// Gets the new selected object.
+    /// </summary>
+    public object? NewObject { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SelectedObjectChangedEventArgs"/> class.
+    /// </summary>
+    public SelectedObjectChangedEventArgs(object? oldObject, object? newObject)
+    {
+        OldObject = oldObject;
+        NewObject = newObject;
+    }
+}
+
+/// <summary>
+/// Event arguments for property selection changes.
+/// </summary>
+public class PropertySelectionChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the previously selected property.
+    /// </summary>
+    public PropertyItem? OldProperty { get; }
+
+    /// <summary>
+    /// Gets the newly selected property.
+    /// </summary>
+    public PropertyItem? NewProperty { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertySelectionChangedEventArgs"/> class.
+    /// </summary>
+    public PropertySelectionChangedEventArgs(PropertyItem? oldProperty, PropertyItem? newProperty)
+    {
+        OldProperty = oldProperty;
+        NewProperty = newProperty;
+    }
+}

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyItem.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyItem.cs
@@ -1,0 +1,289 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// Represents a single property item in the PropertyGrid.
+/// </summary>
+public class PropertyItem : INotifyPropertyChanged
+{
+    private object? _value;
+    private bool _isExpanded;
+    private bool _isSelected;
+
+    /// <summary>
+    /// Gets the property info.
+    /// </summary>
+    public PropertyInfo PropertyInfo { get; }
+
+    /// <summary>
+    /// Gets the target object that contains this property.
+    /// </summary>
+    public object Target { get; }
+
+    /// <summary>
+    /// Gets the property name (programmatic).
+    /// </summary>
+    public string Name => PropertyInfo.Name;
+
+    /// <summary>
+    /// Gets the display name (from DisplayNameAttribute or property name).
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Gets the description (from DescriptionAttribute).
+    /// </summary>
+    public string? Description { get; }
+
+    /// <summary>
+    /// Gets the category (from CategoryAttribute or "Misc").
+    /// </summary>
+    public string Category { get; }
+
+    /// <summary>
+    /// Gets the property type.
+    /// </summary>
+    public Type PropertyType => PropertyInfo.PropertyType;
+
+    /// <summary>
+    /// Gets the property type name for display.
+    /// </summary>
+    public string TypeName => GetFriendlyTypeName(PropertyType);
+
+    /// <summary>
+    /// Gets whether this property is read-only.
+    /// </summary>
+    public bool IsReadOnly { get; }
+
+    /// <summary>
+    /// Gets whether this property can be expanded (has sub-properties).
+    /// </summary>
+    public bool IsExpandable { get; }
+
+    /// <summary>
+    /// Gets the sub-properties for expandable items.
+    /// </summary>
+    public IReadOnlyList<PropertyItem> SubProperties { get; }
+
+    /// <summary>
+    /// Gets the minimum value (from RangeAttribute).
+    /// </summary>
+    public object? Minimum { get; }
+
+    /// <summary>
+    /// Gets the maximum value (from RangeAttribute).
+    /// </summary>
+    public object? Maximum { get; }
+
+    /// <summary>
+    /// Gets the custom editor type (from EditorAttribute).
+    /// </summary>
+    public Type? EditorType { get; }
+
+    /// <summary>
+    /// Gets or sets the property value.
+    /// </summary>
+    public object? Value
+    {
+        get => _value;
+        set
+        {
+            if (!Equals(_value, value))
+            {
+                var oldValue = _value;
+                _value = value;
+
+                // Update the actual property
+                if (!IsReadOnly && PropertyInfo.CanWrite)
+                {
+                    try
+                    {
+                        PropertyInfo.SetValue(Target, Convert.ChangeType(value, PropertyType));
+                    }
+                    catch
+                    {
+                        // Revert on failure
+                        _value = oldValue;
+                        return;
+                    }
+                }
+
+                OnPropertyChanged(nameof(Value));
+                OnPropertyChanged(nameof(DisplayValue));
+                ValueChanged?.Invoke(this, new PropertyValueChangedEventArgs(this, oldValue, value));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the display value (formatted for display).
+    /// </summary>
+    public string DisplayValue
+    {
+        get
+        {
+            if (Value == null) return "(null)";
+            if (PropertyType == typeof(Color)) return ((Color)Value).ToHex();
+            if (PropertyType.IsEnum) return Enum.GetName(PropertyType, Value) ?? Value.ToString() ?? "";
+            return Value.ToString() ?? "";
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether this item is expanded (for expandable items).
+    /// </summary>
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set
+        {
+            if (_isExpanded != value)
+            {
+                _isExpanded = value;
+                OnPropertyChanged(nameof(IsExpanded));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether this item is selected.
+    /// </summary>
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (_isSelected != value)
+            {
+                _isSelected = value;
+                OnPropertyChanged(nameof(IsSelected));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Occurs when the property value changes.
+    /// </summary>
+    public event EventHandler<PropertyValueChangedEventArgs>? ValueChanged;
+
+    /// <summary>
+    /// Occurs when a property changes.
+    /// </summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyItem"/> class.
+    /// </summary>
+    public PropertyItem(PropertyInfo propertyInfo, object target)
+    {
+        PropertyInfo = propertyInfo;
+        Target = target;
+
+        // Get display name
+        var displayNameAttr = propertyInfo.GetCustomAttribute<DisplayNameAttribute>();
+        DisplayName = displayNameAttr?.DisplayName ?? propertyInfo.Name;
+
+        // Get description
+        var descAttr = propertyInfo.GetCustomAttribute<DescriptionAttribute>();
+        Description = descAttr?.Description;
+
+        // Get category
+        var categoryAttr = propertyInfo.GetCustomAttribute<CategoryAttribute>();
+        Category = categoryAttr?.Category ?? "Misc";
+
+        // Check if read-only
+        var readOnlyAttr = propertyInfo.GetCustomAttribute<ReadOnlyAttribute>();
+        IsReadOnly = readOnlyAttr?.IsReadOnly ?? !propertyInfo.CanWrite;
+
+        // Get range
+        var rangeAttr = propertyInfo.GetCustomAttribute<RangeAttribute>();
+        Minimum = rangeAttr?.Minimum;
+        Maximum = rangeAttr?.Maximum;
+
+        // Get custom editor
+        var editorAttr = propertyInfo.GetCustomAttribute<EditorAttribute>();
+        if (editorAttr != null && !string.IsNullOrEmpty(editorAttr.EditorTypeName))
+        {
+            EditorType = Type.GetType(editorAttr.EditorTypeName);
+        }
+
+        // Check if expandable (complex object that isn't a string or primitive)
+        IsExpandable = !PropertyType.IsPrimitive
+                       && PropertyType != typeof(string)
+                       && PropertyType != typeof(decimal)
+                       && PropertyType != typeof(DateTime)
+                       && PropertyType != typeof(TimeSpan)
+                       && PropertyType != typeof(Color)
+                       && !PropertyType.IsEnum
+                       && PropertyType.GetProperties().Length > 0;
+
+        // Get sub-properties for expandable items
+        if (IsExpandable)
+        {
+            var subProps = new List<PropertyItem>();
+            var currentValue = propertyInfo.GetValue(target);
+            if (currentValue != null)
+            {
+                foreach (var subProp in PropertyType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (subProp.GetCustomAttribute<BrowsableAttribute>()?.Browsable != false)
+                    {
+                        subProps.Add(new PropertyItem(subProp, currentValue));
+                    }
+                }
+            }
+            SubProperties = subProps;
+        }
+        else
+        {
+            SubProperties = Array.Empty<PropertyItem>();
+        }
+
+        // Get initial value
+        _value = propertyInfo.GetValue(target);
+    }
+
+    /// <summary>
+    /// Refreshes the value from the target object.
+    /// </summary>
+    public void RefreshValue()
+    {
+        var newValue = PropertyInfo.GetValue(Target);
+        if (!Equals(_value, newValue))
+        {
+            _value = newValue;
+            OnPropertyChanged(nameof(Value));
+            OnPropertyChanged(nameof(DisplayValue));
+        }
+    }
+
+    private void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    private static string GetFriendlyTypeName(Type type)
+    {
+        if (type == typeof(int)) return "int";
+        if (type == typeof(string)) return "string";
+        if (type == typeof(bool)) return "bool";
+        if (type == typeof(double)) return "double";
+        if (type == typeof(float)) return "float";
+        if (type == typeof(decimal)) return "decimal";
+        if (type == typeof(DateTime)) return "DateTime";
+        if (type == typeof(TimeSpan)) return "TimeSpan";
+        if (type == typeof(Color)) return "Color";
+        if (type.IsGenericType)
+        {
+            var name = type.Name;
+            var index = name.IndexOf('`');
+            if (index > 0) name = name[..index];
+            var args = string.Join(", ", type.GetGenericArguments().Select(GetFriendlyTypeName));
+            return $"{name}<{args}>";
+        }
+        return type.Name;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a WinForms-style PropertyGrid control that automatically generates an editable UI from an object's properties using reflection.

Closes #11

## Features

- **Automatic property discovery** - Uses reflection to enumerate public properties
- **Category grouping** - Properties can be grouped by `[Category]` attribute with collapsible headers
- **Built-in editors** for common types:
  - Boolean (Switch)
  - String (Entry)
  - Integer/Long/Short/Byte (Numeric Entry)
  - Double/Float/Decimal (Numeric Entry)
  - DateTime (DatePicker)
  - TimeSpan (TimePicker)
  - Color (ColorBox + Hex Entry)
  - Enums (Picker)
- **Search/filter** - Filter properties by name or description
- **Description panel** - Shows property details when selected
- **Custom editors** - Support via `IPropertyEditor` interface
- **Sort modes** - Categorized, Alphabetical, or None
- **Keyboard navigation** - Full `IKeyboardNavigable` support (Arrow keys, Home, End)
- **ReadOnly mode** - Disable editing for entire grid
- **Value change events** - Including cancelable `PropertyValueChanging`
- **MVVM support** - Commands for all events

## Files Added

| File | Purpose |
|------|---------|
| `PropertyGrid.xaml` | Control layout with search, properties list, description panel |
| `PropertyGrid.xaml.cs` | Control code-behind with property discovery and editors |
| `PropertyItem.cs` | Represents a single property with reflection metadata |
| `PropertyCategory.cs` | Represents a category of properties |
| `PropertyGridEnums.cs` | `PropertySortMode` enum |
| `PropertyGridEventArgs.cs` | Event args for value changes, selection changes |
| `IPropertyEditor.cs` | Interface for custom property editors |

## Test Plan

- [ ] Set `SelectedObject` to a POCO and verify properties appear
- [ ] Verify category grouping with `[Category]` attribute
- [ ] Test built-in editors for each supported type
- [ ] Test search filtering
- [ ] Test keyboard navigation
- [ ] Verify `PropertyValueChanged` event fires on edit
- [ ] Test custom editor via `[Editor]` attribute