### PR TITLE
feat: add Breadcrumb navigation control (#15)

### DIFF
--- a/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml
+++ b/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<base:StyledControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                        xmlns:base="clr-namespace:MauiControlsExtras.Base"
+                        xmlns:local="clr-namespace:MauiControlsExtras.Controls"
+                        x:Class="MauiControlsExtras.Controls.Breadcrumb"
+                        x:Name="thisControl">
+
+    <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
+            Stroke="{Binding EffectiveBorderColor, Source={x:Reference thisControl}}"
+            BackgroundColor="{Binding EffectiveBackgroundColor, Source={x:Reference thisControl}}"
+            Padding="{Binding Padding, Source={x:Reference thisControl}}">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="{Binding EffectiveCornerRadius, Source={x:Reference thisControl}}" />
+        </Border.StrokeShape>
+
+        <ScrollView Orientation="Horizontal"
+                    HorizontalScrollBarVisibility="Never">
+            <HorizontalStackLayout x:Name="itemsContainer"
+                                   Spacing="0"
+                                   VerticalOptions="Center" />
+        </ScrollView>
+    </Border>
+</base:StyledControlBase>

--- a/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml.cs
@@ -1,0 +1,866 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Windows.Input;
+using MauiControlsExtras.Base;
+using MauiControlsExtras.Theming;
+
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// A breadcrumb navigation control showing the current location in a hierarchy.
+/// </summary>
+public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable
+{
+    #region Private Fields
+
+    private readonly ObservableCollection<BreadcrumbItem> _items = new();
+    private int _selectedIndex = -1;
+    private bool _hasKeyboardFocus;
+
+    #endregion
+
+    #region Bindable Properties
+
+    /// <summary>
+    /// Identifies the <see cref="Separator"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SeparatorProperty = BindableProperty.Create(
+        nameof(Separator),
+        typeof(string),
+        typeof(Breadcrumb),
+        "/",
+        propertyChanged: OnSeparatorChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="SeparatorTemplate"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SeparatorTemplateProperty = BindableProperty.Create(
+        nameof(SeparatorTemplate),
+        typeof(DataTemplate),
+        typeof(Breadcrumb),
+        null,
+        propertyChanged: OnSeparatorChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="ItemTemplate"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(
+        nameof(ItemTemplate),
+        typeof(DataTemplate),
+        typeof(Breadcrumb),
+        null,
+        propertyChanged: OnItemTemplateChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="ShowHomeIcon"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ShowHomeIconProperty = BindableProperty.Create(
+        nameof(ShowHomeIcon),
+        typeof(bool),
+        typeof(Breadcrumb),
+        true,
+        propertyChanged: OnShowHomeIconChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="HomeIcon"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty HomeIconProperty = BindableProperty.Create(
+        nameof(HomeIcon),
+        typeof(string),
+        typeof(Breadcrumb),
+        "🏠",
+        propertyChanged: OnShowHomeIconChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="ItemSpacing"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ItemSpacingProperty = BindableProperty.Create(
+        nameof(ItemSpacing),
+        typeof(double),
+        typeof(Breadcrumb),
+        8.0,
+        propertyChanged: OnItemSpacingChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="FontSize"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty FontSizeProperty = BindableProperty.Create(
+        nameof(FontSize),
+        typeof(double),
+        typeof(Breadcrumb),
+        14.0);
+
+    /// <summary>
+    /// Identifies the <see cref="ActiveItemColor"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ActiveItemColorProperty = BindableProperty.Create(
+        nameof(ActiveItemColor),
+        typeof(Color),
+        typeof(Breadcrumb),
+        null);
+
+    /// <summary>
+    /// Identifies the <see cref="InactiveItemColor"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty InactiveItemColorProperty = BindableProperty.Create(
+        nameof(InactiveItemColor),
+        typeof(Color),
+        typeof(Breadcrumb),
+        null);
+
+    /// <summary>
+    /// Identifies the <see cref="SeparatorColor"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SeparatorColorProperty = BindableProperty.Create(
+        nameof(SeparatorColor),
+        typeof(Color),
+        typeof(Breadcrumb),
+        null);
+
+    /// <summary>
+    /// Identifies the <see cref="HoverUnderline"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty HoverUnderlineProperty = BindableProperty.Create(
+        nameof(HoverUnderline),
+        typeof(bool),
+        typeof(Breadcrumb),
+        true);
+
+    /// <summary>
+    /// Identifies the <see cref="MaxVisibleItems"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty MaxVisibleItemsProperty = BindableProperty.Create(
+        nameof(MaxVisibleItems),
+        typeof(int),
+        typeof(Breadcrumb),
+        0,
+        propertyChanged: OnMaxVisibleItemsChanged);
+
+    /// <summary>
+    /// Identifies the <see cref="CollapsedIndicator"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CollapsedIndicatorProperty = BindableProperty.Create(
+        nameof(CollapsedIndicator),
+        typeof(string),
+        typeof(Breadcrumb),
+        "...");
+
+    /// <summary>
+    /// Identifies the <see cref="IsKeyboardNavigationEnabled"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty IsKeyboardNavigationEnabledProperty = BindableProperty.Create(
+        nameof(IsKeyboardNavigationEnabled),
+        typeof(bool),
+        typeof(Breadcrumb),
+        true);
+
+    #endregion
+
+    #region Command Properties
+
+    /// <summary>
+    /// Identifies the <see cref="ItemClickedCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ItemClickedCommandProperty = BindableProperty.Create(
+        nameof(ItemClickedCommand),
+        typeof(ICommand),
+        typeof(Breadcrumb));
+
+    /// <summary>
+    /// Identifies the <see cref="HomeClickedCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty HomeClickedCommandProperty = BindableProperty.Create(
+        nameof(HomeClickedCommand),
+        typeof(ICommand),
+        typeof(Breadcrumb));
+
+    /// <summary>
+    /// Identifies the <see cref="GotFocusCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandProperty = BindableProperty.Create(
+        nameof(GotFocusCommand),
+        typeof(ICommand),
+        typeof(Breadcrumb));
+
+    /// <summary>
+    /// Identifies the <see cref="LostFocusCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandProperty = BindableProperty.Create(
+        nameof(LostFocusCommand),
+        typeof(ICommand),
+        typeof(Breadcrumb));
+
+    /// <summary>
+    /// Identifies the <see cref="KeyPressCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandProperty = BindableProperty.Create(
+        nameof(KeyPressCommand),
+        typeof(ICommand),
+        typeof(Breadcrumb));
+
+    #endregion
+
+    #region Properties
+
+    /// <summary>
+    /// Gets or sets the separator string between items.
+    /// </summary>
+    public string Separator
+    {
+        get => (string)GetValue(SeparatorProperty);
+        set => SetValue(SeparatorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a custom template for the separator.
+    /// </summary>
+    public DataTemplate? SeparatorTemplate
+    {
+        get => (DataTemplate?)GetValue(SeparatorTemplateProperty);
+        set => SetValue(SeparatorTemplateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a custom template for items.
+    /// </summary>
+    public DataTemplate? ItemTemplate
+    {
+        get => (DataTemplate?)GetValue(ItemTemplateProperty);
+        set => SetValue(ItemTemplateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the home icon is shown.
+    /// </summary>
+    public bool ShowHomeIcon
+    {
+        get => (bool)GetValue(ShowHomeIconProperty);
+        set => SetValue(ShowHomeIconProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the home icon.
+    /// </summary>
+    public string HomeIcon
+    {
+        get => (string)GetValue(HomeIconProperty);
+        set => SetValue(HomeIconProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the spacing between items.
+    /// </summary>
+    public double ItemSpacing
+    {
+        get => (double)GetValue(ItemSpacingProperty);
+        set => SetValue(ItemSpacingProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the font size.
+    /// </summary>
+    public double FontSize
+    {
+        get => (double)GetValue(FontSizeProperty);
+        set => SetValue(FontSizeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the color for the current (active) item.
+    /// </summary>
+    public Color? ActiveItemColor
+    {
+        get => (Color?)GetValue(ActiveItemColorProperty);
+        set => SetValue(ActiveItemColorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the color for inactive (clickable) items.
+    /// </summary>
+    public Color? InactiveItemColor
+    {
+        get => (Color?)GetValue(InactiveItemColorProperty);
+        set => SetValue(InactiveItemColorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the separator color.
+    /// </summary>
+    public Color? SeparatorColor
+    {
+        get => (Color?)GetValue(SeparatorColorProperty);
+        set => SetValue(SeparatorColorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether items show underline on hover.
+    /// </summary>
+    public bool HoverUnderline
+    {
+        get => (bool)GetValue(HoverUnderlineProperty);
+        set => SetValue(HoverUnderlineProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum visible items (0 = show all).
+    /// When exceeded, middle items are collapsed.
+    /// </summary>
+    public int MaxVisibleItems
+    {
+        get => (int)GetValue(MaxVisibleItemsProperty);
+        set => SetValue(MaxVisibleItemsProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the indicator shown for collapsed items.
+    /// </summary>
+    public string CollapsedIndicator
+    {
+        get => (string)GetValue(CollapsedIndicatorProperty);
+        set => SetValue(CollapsedIndicatorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the collection of breadcrumb items.
+    /// </summary>
+    public ObservableCollection<BreadcrumbItem> Items => _items;
+
+    /// <summary>
+    /// Gets the effective active item color.
+    /// </summary>
+    public Color EffectiveActiveItemColor =>
+        ActiveItemColor ?? EffectiveForegroundColor;
+
+    /// <summary>
+    /// Gets the effective inactive item color.
+    /// </summary>
+    public Color EffectiveInactiveItemColor =>
+        InactiveItemColor ?? EffectiveAccentColor;
+
+    /// <summary>
+    /// Gets the effective separator color.
+    /// </summary>
+    public Color EffectiveSeparatorColor =>
+        SeparatorColor ?? MauiControlsExtrasTheme.GetForegroundColor().WithAlpha(0.5f);
+
+    #endregion
+
+    #region Command Properties Implementation
+
+    /// <summary>
+    /// Gets or sets the command executed when an item is clicked.
+    /// </summary>
+    public ICommand? ItemClickedCommand
+    {
+        get => (ICommand?)GetValue(ItemClickedCommandProperty);
+        set => SetValue(ItemClickedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command executed when the home icon is clicked.
+    /// </summary>
+    public ICommand? HomeClickedCommand
+    {
+        get => (ICommand?)GetValue(HomeClickedCommandProperty);
+        set => SetValue(HomeClickedCommandProperty, value);
+    }
+
+    /// <inheritdoc/>
+    public ICommand? GotFocusCommand
+    {
+        get => (ICommand?)GetValue(GotFocusCommandProperty);
+        set => SetValue(GotFocusCommandProperty, value);
+    }
+
+    /// <inheritdoc/>
+    public ICommand? LostFocusCommand
+    {
+        get => (ICommand?)GetValue(LostFocusCommandProperty);
+        set => SetValue(LostFocusCommandProperty, value);
+    }
+
+    /// <inheritdoc/>
+    public ICommand? KeyPressCommand
+    {
+        get => (ICommand?)GetValue(KeyPressCommandProperty);
+        set => SetValue(KeyPressCommandProperty, value);
+    }
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Occurs when an item is clicked.
+    /// </summary>
+    public event EventHandler<BreadcrumbItemClickedEventArgs>? ItemClicked;
+
+    /// <summary>
+    /// Occurs before navigating to an item (cancelable).
+    /// </summary>
+    public event EventHandler<BreadcrumbNavigatingEventArgs>? Navigating;
+
+    /// <summary>
+    /// Occurs when the home icon is clicked.
+    /// </summary>
+    public event EventHandler? HomeClicked;
+
+    /// <inheritdoc/>
+    public event EventHandler<KeyboardFocusEventArgs>? KeyboardFocusGained;
+
+    /// <inheritdoc/>
+#pragma warning disable CS0067
+    public event EventHandler<KeyboardFocusEventArgs>? KeyboardFocusLost;
+#pragma warning restore CS0067
+
+    /// <inheritdoc/>
+    public event EventHandler<KeyEventArgs>? KeyPressed;
+
+    /// <inheritdoc/>
+#pragma warning disable CS0067
+    public event EventHandler<KeyEventArgs>? KeyReleased;
+#pragma warning restore CS0067
+
+    #endregion
+
+    #region IKeyboardNavigable Implementation
+
+    /// <inheritdoc/>
+    public bool CanReceiveFocus => IsEnabled && IsVisible;
+
+    /// <inheritdoc/>
+    public bool IsKeyboardNavigationEnabled
+    {
+        get => (bool)GetValue(IsKeyboardNavigationEnabledProperty);
+        set => SetValue(IsKeyboardNavigationEnabledProperty, value);
+    }
+
+    /// <inheritdoc/>
+    public bool HasKeyboardFocus => _hasKeyboardFocus;
+
+    /// <inheritdoc/>
+    public bool HandleKeyPress(KeyEventArgs e)
+    {
+        if (!IsKeyboardNavigationEnabled) return false;
+
+        KeyPressed?.Invoke(this, e);
+        if (e.Handled) return true;
+
+        if (KeyPressCommand?.CanExecute(e) == true)
+        {
+            KeyPressCommand.Execute(e);
+            if (e.Handled) return true;
+        }
+
+        switch (e.Key)
+        {
+            case "ArrowLeft":
+                SelectPreviousItem();
+                return true;
+            case "ArrowRight":
+                SelectNextItem();
+                return true;
+            case "Home":
+                SelectFirstItem();
+                return true;
+            case "End":
+                SelectLastItem();
+                return true;
+            case "Enter":
+            case " ":
+                ActivateSelectedItem();
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<KeyboardShortcut> GetKeyboardShortcuts()
+    {
+        return new List<KeyboardShortcut>
+        {
+            new() { Key = "ArrowLeft", Description = "Select previous item", Category = "Navigation" },
+            new() { Key = "ArrowRight", Description = "Select next item", Category = "Navigation" },
+            new() { Key = "Home", Description = "Select first item", Category = "Navigation" },
+            new() { Key = "End", Description = "Select last item", Category = "Navigation" },
+            new() { Key = "Enter", Description = "Navigate to selected item", Category = "Actions" },
+            new() { Key = "Space", Description = "Navigate to selected item", Category = "Actions" }
+        };
+    }
+
+    /// <inheritdoc/>
+    public new bool Focus()
+    {
+        if (!CanReceiveFocus) return false;
+        _hasKeyboardFocus = true;
+        OnPropertyChanged(nameof(HasKeyboardFocus));
+        KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
+        GotFocusCommand?.Execute(this);
+
+        if (_selectedIndex < 0 && _items.Count > 0)
+        {
+            _selectedIndex = 0;
+        }
+
+        RebuildUI();
+        return true;
+    }
+
+    #endregion
+
+    #region Constructor
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Breadcrumb"/> class.
+    /// </summary>
+    public Breadcrumb()
+    {
+        InitializeComponent();
+        _items.CollectionChanged += OnItemsCollectionChanged;
+    }
+
+    #endregion
+
+    #region Navigation Methods
+
+    private void SelectPreviousItem()
+    {
+        if (_items.Count == 0) return;
+        _selectedIndex = _selectedIndex > 0 ? _selectedIndex - 1 : _items.Count - 1;
+        RebuildUI();
+    }
+
+    private void SelectNextItem()
+    {
+        if (_items.Count == 0) return;
+        _selectedIndex = (_selectedIndex + 1) % _items.Count;
+        RebuildUI();
+    }
+
+    private void SelectFirstItem()
+    {
+        if (_items.Count == 0) return;
+        _selectedIndex = 0;
+        RebuildUI();
+    }
+
+    private void SelectLastItem()
+    {
+        if (_items.Count == 0) return;
+        _selectedIndex = _items.Count - 1;
+        RebuildUI();
+    }
+
+    private void ActivateSelectedItem()
+    {
+        if (_selectedIndex >= 0 && _selectedIndex < _items.Count)
+        {
+            OnItemClicked(_items[_selectedIndex], _selectedIndex);
+        }
+    }
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// Adds a breadcrumb item.
+    /// </summary>
+    public void AddItem(string text, object? tag = null)
+    {
+        _items.Add(new BreadcrumbItem { Text = text, Tag = tag });
+    }
+
+    /// <summary>
+    /// Adds a breadcrumb item with icon.
+    /// </summary>
+    public void AddItem(string text, string icon, object? tag = null)
+    {
+        _items.Add(new BreadcrumbItem { Text = text, Icon = icon, Tag = tag });
+    }
+
+    /// <summary>
+    /// Navigates to an item, removing all items after it.
+    /// </summary>
+    public void NavigateTo(int index)
+    {
+        if (index < 0 || index >= _items.Count) return;
+
+        var item = _items[index];
+
+        // Raise navigating event
+        var navArgs = new BreadcrumbNavigatingEventArgs(item, index);
+        Navigating?.Invoke(this, navArgs);
+        if (navArgs.Cancel) return;
+
+        // Remove items after clicked index
+        while (_items.Count > index + 1)
+        {
+            _items.RemoveAt(_items.Count - 1);
+        }
+    }
+
+    /// <summary>
+    /// Clears all breadcrumb items.
+    /// </summary>
+    public void Clear()
+    {
+        _items.Clear();
+    }
+
+    #endregion
+
+    #region UI Building
+
+    private void RebuildUI()
+    {
+        itemsContainer.Children.Clear();
+
+        // Update item indices and current state
+        for (int i = 0; i < _items.Count; i++)
+        {
+            _items[i].Index = i;
+            _items[i].IsCurrent = i == _items.Count - 1;
+        }
+
+        // Home icon
+        if (ShowHomeIcon)
+        {
+            var homeView = CreateHomeIcon();
+            itemsContainer.Children.Add(homeView);
+
+            if (_items.Count > 0)
+            {
+                itemsContainer.Children.Add(CreateSeparator());
+            }
+        }
+
+        // Determine visible items
+        var visibleItems = GetVisibleItems();
+
+        for (int i = 0; i < visibleItems.Count; i++)
+        {
+            var item = visibleItems[i];
+
+            if (item == null)
+            {
+                // Collapsed indicator
+                var collapsed = CreateCollapsedIndicator();
+                itemsContainer.Children.Add(collapsed);
+            }
+            else
+            {
+                var itemView = CreateItemView(item);
+                itemsContainer.Children.Add(itemView);
+            }
+
+            // Add separator (except after last item)
+            if (i < visibleItems.Count - 1)
+            {
+                itemsContainer.Children.Add(CreateSeparator());
+            }
+        }
+    }
+
+    private List<BreadcrumbItem?> GetVisibleItems()
+    {
+        if (MaxVisibleItems <= 0 || _items.Count <= MaxVisibleItems)
+        {
+            return _items.ToList<BreadcrumbItem?>();
+        }
+
+        // Show first item, collapsed indicator, then last (MaxVisibleItems - 2) items
+        var result = new List<BreadcrumbItem?>();
+        result.Add(_items[0]); // First item
+        result.Add(null); // Collapsed indicator
+
+        var startIndex = _items.Count - (MaxVisibleItems - 2);
+        for (int i = startIndex; i < _items.Count; i++)
+        {
+            result.Add(_items[i]);
+        }
+
+        return result;
+    }
+
+    private View CreateHomeIcon()
+    {
+        var label = new Label
+        {
+            Text = HomeIcon,
+            FontSize = FontSize,
+            VerticalOptions = LayoutOptions.Center,
+            TextColor = EffectiveInactiveItemColor
+        };
+
+        var tapGesture = new TapGestureRecognizer();
+        tapGesture.Tapped += (s, e) =>
+        {
+            HomeClicked?.Invoke(this, EventArgs.Empty);
+            HomeClickedCommand?.Execute(null);
+        };
+        label.GestureRecognizers.Add(tapGesture);
+
+        return label;
+    }
+
+    private View CreateItemView(BreadcrumbItem item)
+    {
+        View content;
+
+        if (ItemTemplate != null)
+        {
+            content = (View)ItemTemplate.CreateContent();
+            content.BindingContext = item;
+        }
+        else
+        {
+            var stack = new HorizontalStackLayout { Spacing = 4 };
+
+            if (!string.IsNullOrEmpty(item.Icon))
+            {
+                stack.Children.Add(new Label
+                {
+                    Text = item.Icon,
+                    FontSize = FontSize,
+                    VerticalOptions = LayoutOptions.Center,
+                    TextColor = GetItemColor(item)
+                });
+            }
+
+            var textLabel = new Label
+            {
+                Text = item.Text,
+                FontSize = FontSize,
+                VerticalOptions = LayoutOptions.Center,
+                TextColor = GetItemColor(item),
+                TextDecorations = item.IsCurrent ? TextDecorations.None :
+                    (HoverUnderline ? TextDecorations.Underline : TextDecorations.None)
+            };
+
+            // Selection highlight
+            if (_hasKeyboardFocus && item.Index == _selectedIndex)
+            {
+                textLabel.BackgroundColor = MauiControlsExtrasTheme.Current.SelectedBackgroundColor;
+            }
+
+            stack.Children.Add(textLabel);
+            content = stack;
+        }
+
+        // Click handler (only for non-current items)
+        if (!item.IsCurrent && item.IsEnabled)
+        {
+            var tapGesture = new TapGestureRecognizer();
+            var capturedItem = item;
+            var capturedIndex = item.Index;
+            tapGesture.Tapped += (s, e) => OnItemClicked(capturedItem, capturedIndex);
+            content.GestureRecognizers.Add(tapGesture);
+        }
+
+        return content;
+    }
+
+    private View CreateSeparator()
+    {
+        if (SeparatorTemplate != null)
+        {
+            return (View)SeparatorTemplate.CreateContent();
+        }
+
+        return new Label
+        {
+            Text = Separator,
+            FontSize = FontSize,
+            VerticalOptions = LayoutOptions.Center,
+            TextColor = EffectiveSeparatorColor,
+            Margin = new Thickness(ItemSpacing, 0)
+        };
+    }
+
+    private View CreateCollapsedIndicator()
+    {
+        return new Label
+        {
+            Text = CollapsedIndicator,
+            FontSize = FontSize,
+            VerticalOptions = LayoutOptions.Center,
+            TextColor = EffectiveSeparatorColor
+        };
+    }
+
+    private Color GetItemColor(BreadcrumbItem item)
+    {
+        if (!item.IsEnabled) return EffectiveDisabledColor;
+        return item.IsCurrent ? EffectiveActiveItemColor : EffectiveInactiveItemColor;
+    }
+
+    #endregion
+
+    #region Event Handlers
+
+    private void OnItemClicked(BreadcrumbItem item, int index)
+    {
+        // Execute item command
+        if (item.Command?.CanExecute(item.CommandParameter) == true)
+        {
+            item.Command.Execute(item.CommandParameter);
+        }
+
+        var args = new BreadcrumbItemClickedEventArgs(item, index);
+        ItemClicked?.Invoke(this, args);
+        ItemClickedCommand?.Execute(args);
+    }
+
+    private void OnItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        RebuildUI();
+    }
+
+    #endregion
+
+    #region Property Changed Handlers
+
+    private static void OnSeparatorChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is Breadcrumb breadcrumb)
+        {
+            breadcrumb.RebuildUI();
+        }
+    }
+
+    private static void OnItemTemplateChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is Breadcrumb breadcrumb)
+        {
+            breadcrumb.RebuildUI();
+        }
+    }
+
+    private static void OnShowHomeIconChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is Breadcrumb breadcrumb)
+        {
+            breadcrumb.RebuildUI();
+        }
+    }
+
+    private static void OnItemSpacingChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is Breadcrumb breadcrumb)
+        {
+            breadcrumb.RebuildUI();
+        }
+    }
+
+    private static void OnMaxVisibleItemsChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is Breadcrumb breadcrumb)
+        {
+            breadcrumb.RebuildUI();
+        }
+    }
+
+    #endregion
+}

--- a/src/MauiControlsExtras/Controls/Breadcrumb/BreadcrumbEventArgs.cs
+++ b/src/MauiControlsExtras/Controls/Breadcrumb/BreadcrumbEventArgs.cs
@@ -1,0 +1,56 @@
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// Event arguments for breadcrumb item click.
+/// </summary>
+public class BreadcrumbItemClickedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the clicked item.
+    /// </summary>
+    public BreadcrumbItem Item { get; }
+
+    /// <summary>
+    /// Gets the item index.
+    /// </summary>
+    public int Index { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BreadcrumbItemClickedEventArgs"/> class.
+    /// </summary>
+    public BreadcrumbItemClickedEventArgs(BreadcrumbItem item, int index)
+    {
+        Item = item;
+        Index = index;
+    }
+}
+
+/// <summary>
+/// Event arguments for breadcrumb navigation (cancelable).
+/// </summary>
+public class BreadcrumbNavigatingEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the target item.
+    /// </summary>
+    public BreadcrumbItem TargetItem { get; }
+
+    /// <summary>
+    /// Gets the target index.
+    /// </summary>
+    public int TargetIndex { get; }
+
+    /// <summary>
+    /// Gets or sets whether the navigation should be cancelled.
+    /// </summary>
+    public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BreadcrumbNavigatingEventArgs"/> class.
+    /// </summary>
+    public BreadcrumbNavigatingEventArgs(BreadcrumbItem targetItem, int targetIndex)
+    {
+        TargetItem = targetItem;
+        TargetIndex = targetIndex;
+    }
+}

--- a/src/MauiControlsExtras/Controls/Breadcrumb/BreadcrumbItem.cs
+++ b/src/MauiControlsExtras/Controls/Breadcrumb/BreadcrumbItem.cs
@@ -1,0 +1,138 @@
+using System.ComponentModel;
+using System.Windows.Input;
+
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// Represents a single item in a breadcrumb navigation.
+/// </summary>
+public class BreadcrumbItem : INotifyPropertyChanged
+{
+    private string? _text;
+    private string? _icon;
+    private object? _tag;
+    private bool _isEnabled = true;
+    private bool _isCurrent;
+
+    /// <summary>
+    /// Gets or sets the display text.
+    /// </summary>
+    public string? Text
+    {
+        get => _text;
+        set
+        {
+            if (_text != value)
+            {
+                _text = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Text)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the icon (glyph character).
+    /// </summary>
+    public string? Icon
+    {
+        get => _icon;
+        set
+        {
+            if (_icon != value)
+            {
+                _icon = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Icon)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets custom data associated with this item.
+    /// </summary>
+    public object? Tag
+    {
+        get => _tag;
+        set
+        {
+            if (_tag != value)
+            {
+                _tag = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Tag)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether this item is enabled (clickable).
+    /// </summary>
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set
+        {
+            if (_isEnabled != value)
+            {
+                _isEnabled = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsEnabled)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets whether this item is the current (last) item.
+    /// </summary>
+    public bool IsCurrent
+    {
+        get => _isCurrent;
+        internal set
+        {
+            if (_isCurrent != value)
+            {
+                _isCurrent = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsCurrent)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the item index within the breadcrumb.
+    /// </summary>
+    public int Index { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets a command executed when this item is clicked.
+    /// </summary>
+    public ICommand? Command { get; set; }
+
+    /// <summary>
+    /// Gets or sets the command parameter.
+    /// </summary>
+    public object? CommandParameter { get; set; }
+
+    /// <summary>
+    /// Occurs when a property value changes.
+    /// </summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BreadcrumbItem"/> class.
+    /// </summary>
+    public BreadcrumbItem() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BreadcrumbItem"/> class with text.
+    /// </summary>
+    public BreadcrumbItem(string text)
+    {
+        Text = text;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BreadcrumbItem"/> class with text and icon.
+    /// </summary>
+    public BreadcrumbItem(string text, string icon)
+    {
+        Text = text;
+        Icon = icon;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Breadcrumb navigation control showing the current location in a hierarchy with clickable links to parent items.

Closes #15

## Features

- **Customizable separator**: Use text ("/", ">") or custom DataTemplate
- **Home icon**: Optional home icon at the start
- **Item templates**: Custom DataTemplate for items
- **Collapsible items**: When exceeding MaxVisibleItems, middle items collapse to "..."
- **Cancelable navigation**: Cancel navigation before it happens
- **Keyboard navigation**: Arrow keys, Home/End, Enter/Space
- **Hover effects**: Optional underline on hover for clickable items
- **MVVM ready**: Commands for item clicks and home clicks

## Files Added

| File | Purpose |
|------|---------|
| `Breadcrumb.xaml` | Control layout with scrollable items container |
| `Breadcrumb.xaml.cs` | Control logic with navigation and item management |
| `BreadcrumbItem.cs` | Individual breadcrumb item class |
| `BreadcrumbEventArgs.cs` | Event args for item clicks and navigation |

## Usage Example

```xml
<controls:Breadcrumb Separator="/"
                     ShowHomeIcon="True"
                     ItemClicked="OnBreadcrumbItemClicked">
    <!-- Items can be added in XAML or code-behind -->
</controls:Breadcrumb>
```

```csharp
breadcrumb.AddItem("Home", "🏠");
breadcrumb.AddItem("Documents", "📁");
breadcrumb.AddItem("Reports", "📄");
breadcrumb.AddItem("Q4 Report");
```

## Test Plan

- [ ] Add items and verify rendering
- [ ] Test separator customization
- [ ] Verify clicking navigates and removes following items
- [ ] Test MaxVisibleItems collapsing
- [ ] Test keyboard navigation
- [ ] Verify home icon click event fires