### PR TITLE
feat(RichTextEditor): add dark theme support with dynamic switching

### DIFF
--- a/src/MauiControlsExtras/Controls/RichTextEditor/FormatType.cs
+++ b/src/MauiControlsExtras/Controls/RichTextEditor/FormatType.cs
@@ -123,3 +123,24 @@ public enum QuillJsSource
     /// </summary>
     Custom
 }
+
+/// <summary>
+/// Specifies the theme mode for the RichTextEditor.
+/// </summary>
+public enum EditorThemeMode
+{
+    /// <summary>
+    /// Automatically follow the system/app theme.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Always use light theme.
+    /// </summary>
+    Light,
+
+    /// <summary>
+    /// Always use dark theme.
+    /// </summary>
+    Dark
+}


### PR DESCRIPTION
## Summary

Closes #40

Implements comprehensive dark theme support for the RichTextEditor with dynamic theme switching, following the [DEV Community approach](https://dev.to/chocoscoding/editing-react-quilljs-markdown-styling-3c4h) using CSS variables and inheritance.

### Changes

**New `EditorThemeMode` enum:**
- `Auto` (default) - Follows system/app theme automatically
- `Light` - Forces light theme
- `Dark` - Forces dark theme

**CSS Variables for Theming:**
```css
--editor-bg          /* Background color */
--editor-text        /* Text color */
--editor-placeholder /* Placeholder color */
--editor-border      /* Border color */
--editor-link        /* Link color */
--editor-code-bg     /* Code block background */
--editor-code-text   /* Code block text */
--editor-blockquote-border /* Blockquote border */
--editor-selection-bg /* Selection highlight */
```

**Dynamic Theme Switching:**
- Subscribes to `Application.RequestedThemeChanged` when `ThemeMode == Auto`
- Theme switches instantly via JavaScript without reinitializing editor
- Smooth CSS transitions (0.2s) for background and text colors

**New Public API:**
```csharp
// Property
public EditorThemeMode ThemeMode { get; set; }
public bool IsDarkTheme { get; } // Read-only computed property

// Methods
public Task UpdateThemeAsync(bool isDark);
public Task RefreshThemeAsync();
```

### Usage

```xml
<!-- Auto mode (default) - follows system theme -->
<controls:RichTextEditor />

<!-- Force dark theme -->
<controls:RichTextEditor ThemeMode="Dark" />

<!-- Force light theme -->
<controls:RichTextEditor ThemeMode="Light" />
```

## Test Plan

- [ ] Editor displays correctly in light mode
- [ ] Editor displays correctly in dark mode
- [ ] Auto mode follows system theme changes dynamically
- [ ] ThemeMode="Light" forces light theme regardless of system
- [ ] ThemeMode="Dark" forces dark theme regardless of system
- [ ] Code blocks, blockquotes, links styled correctly in both themes
- [ ] Selection highlight visible in both themes
- [ ] Smooth transitions when theme changes
- [ ] No flickering during theme switch