### PR TITLE
docs: update README with all 16 controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,41 @@
 # MAUI Controls Extras
 
-A collection of enhanced UI controls for .NET MAUI applications that fill gaps in the standard control library.
+A comprehensive collection of 16 enterprise-grade UI controls for .NET MAUI applications that fill gaps in the standard control library.
 
 [![NuGet](https://img.shields.io/nuget/v/StefK.MauiControlsExtras.svg)](https://www.nuget.org/packages/StefK.MauiControlsExtras/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Features
+## Available Controls
 
-### ComboBox Control
+| Control | Description |
+|---------|-------------|
+| **Accordion** | Expandable/collapsible sections with single or multiple expand modes |
+| **BindingNavigator** | Data navigation toolbar for browsing collections |
+| **Breadcrumb** | Hierarchical navigation path display |
+| **Calendar** | Date picker with single, multiple, and range selection modes |
+| **ComboBox** | Searchable dropdown with complex object and icon support |
+| **DataGridView** | Enterprise data grid with sorting, filtering, grouping, and editing |
+| **MaskedEntry** | Text input with format masks (phone, date, SSN, etc.) |
+| **MultiSelectComboBox** | Multi-selection dropdown with checkboxes |
+| **NumericUpDown** | Numeric input with increment/decrement buttons |
+| **PropertyGrid** | Property editor similar to Visual Studio Properties panel |
+| **RangeSlider** | Dual-thumb slider for range selection |
+| **Rating** | Star/icon-based rating control |
+| **RichTextEditor** | WYSIWYG HTML/Markdown editor with Quill.js |
+| **TokenEntry** | Tag/token input with autocomplete |
+| **TreeView** | Hierarchical tree view with expand/collapse |
+| **Wizard** | Step-by-step wizard/stepper for multi-page forms |
 
-A feature-rich dropdown control similar to WinForms ComboBox, with modern mobile-friendly features:
+## Key Features
 
-- **Searchable/Filterable** - Built-in search with debounced input
-- **Complex Object Support** - Use `DisplayMemberPath` and `ValueMemberPath` for data binding
-- **Image/Icon Support** - Display images alongside text via `IconMemberPath`
-- **Two-Way Binding** - Full support for `SelectedItem` and `SelectedValue` binding
-- **Theme-Aware** - Automatic light/dark mode styling
-- **Customizable** - Placeholder text, accent colors, visible item count
-- **Clear Selection** - Built-in clear button
+- **Cross-Platform** - Android, iOS, macOS Catalyst, and Windows
+- **Keyboard Navigation** - Full keyboard support on desktop platforms
+- **Mouse Interaction** - Click, double-click, right-click, hover, scroll
+- **Clipboard Support** - Ctrl+C/V/X for copy/paste operations
+- **Undo/Redo** - Ctrl+Z/Y for undoable operations
+- **Theme-Aware** - Automatic light/dark mode support
+- **MVVM-Friendly** - Full data binding with commands
+- **MIT Licensed** - Free for commercial and personal use
 
 ## Installation
 
@@ -41,94 +59,41 @@ dotnet add package StefK.MauiControlsExtras
 xmlns:extras="clr-namespace:MauiControlsExtras.Controls;assembly=MauiControlsExtras"
 ```
 
-### 2. Basic Usage
+### 2. Use the controls
 
 ```xml
+<!-- ComboBox with search -->
 <extras:ComboBox ItemsSource="{Binding Countries}"
                  SelectedItem="{Binding SelectedCountry, Mode=TwoWay}"
                  DisplayMemberPath="Name"
                  Placeholder="Select a country..." />
-```
 
-### 3. With Icons
+<!-- DataGrid with sorting and filtering -->
+<extras:DataGridView ItemsSource="{Binding Employees}"
+                     CanUserEdit="True"
+                     EnableSorting="True"
+                     EnableFiltering="True">
+    <extras:DataGridView.Columns>
+        <extras:DataGridTextColumn Header="Name" Binding="Name" />
+        <extras:DataGridTextColumn Header="Department" Binding="Department" />
+        <extras:DataGridNumericColumn Header="Salary" Binding="Salary" Format="C0" />
+    </extras:DataGridView.Columns>
+</extras:DataGridView>
 
-```xml
-<extras:ComboBox ItemsSource="{Binding Icons}"
-                 SelectedItem="{Binding SelectedIcon, Mode=TwoWay}"
-                 DisplayMemberPath="DisplayName"
-                 IconMemberPath="ImagePath"
-                 Placeholder="Select an icon..."
-                 VisibleItemCount="6" />
-```
+<!-- RichTextEditor with dark theme support -->
+<extras:RichTextEditor HtmlContent="{Binding Content, Mode=TwoWay}"
+                       ThemeMode="Auto"
+                       Placeholder="Start typing..." />
 
-## API Reference
+<!-- Calendar with date range selection -->
+<extras:Calendar SelectionMode="Range"
+                 RangeStart="{Binding StartDate, Mode=TwoWay}"
+                 RangeEnd="{Binding EndDate, Mode=TwoWay}" />
 
-### ComboBox Properties
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `ItemsSource` | `IEnumerable` | `null` | The collection of items to display |
-| `SelectedItem` | `object` | `null` | The currently selected item (two-way) |
-| `SelectedValue` | `object` | `null` | The selected value based on ValueMemberPath (two-way) |
-| `DisplayMemberPath` | `string` | `null` | Property path for display text |
-| `ValueMemberPath` | `string` | `null` | Property path for the value |
-| `IconMemberPath` | `string` | `null` | Property path for item icons |
-| `Placeholder` | `string` | `"Select an item"` | Text shown when no selection |
-| `DefaultValue` | `object` | `null` | Value to select on initialization |
-| `VisibleItemCount` | `int` | `5` | Number of visible items in dropdown |
-| `AccentColor` | `Color` | `#0078D4` | Color used for focus indication |
-| `HasSelection` | `bool` | `false` | Whether an item is selected (read-only) |
-| `IsExpanded` | `bool` | `false` | Whether dropdown is open (read-only) |
-
-### ComboBox Events
-
-| Event | Description |
-|-------|-------------|
-| `SelectionChanged` | Raised when the selected item changes |
-| `Opened` | Raised when the dropdown opens |
-| `Closed` | Raised when the dropdown closes |
-
-### ComboBox Methods
-
-| Method | Description |
-|--------|-------------|
-| `Open()` | Programmatically opens the dropdown |
-| `Close()` | Programmatically closes the dropdown |
-| `ClearSelection()` | Clears the current selection |
-| `RefreshItems()` | Refreshes the filtered items list |
-
-## Examples
-
-### Activity Selection (Simple)
-
-```xml
-<extras:ComboBox ItemsSource="{Binding ActivityTypes}"
-                 SelectedItem="{Binding SelectedActivity, Mode=TwoWay}"
-                 DisplayMemberPath="Name"
-                 Placeholder="Select an Activity"
-                 VisibleItemCount="5" />
-```
-
-### Icon Picker (With Images)
-
-```xml
-<extras:ComboBox ItemsSource="{Binding Icons}"
-                 SelectedItem="{Binding SelectedIconOption, Mode=TwoWay}"
-                 DisplayMemberPath="DisplayName"
-                 IconMemberPath="IconImageSource"
-                 Placeholder="Select an icon..."
-                 VisibleItemCount="6" />
-```
-
-### With Default Value
-
-```xml
-<extras:ComboBox ItemsSource="{Binding Priorities}"
-                 SelectedItem="{Binding Priority, Mode=TwoWay}"
-                 DisplayMemberPath="Name"
-                 ValueMemberPath="Id"
-                 DefaultValue="normal"
-                 Placeholder="Select priority" />
+<!-- TreeView with hierarchical data -->
+<extras:TreeView ItemsSource="{Binding Folders}"
+                 ChildrenPath="SubFolders"
+                 DisplayMemberPath="Name" />
 ```
 
 ## Supported Platforms
@@ -141,16 +106,21 @@ xmlns:extras="clr-namespace:MauiControlsExtras.Controls;assembly=MauiControlsExt
 ## Requirements
 
 - .NET 10.0 or later
-- .NET MAUI
+- .NET MAUI workload
+
+## Documentation
+
+Full documentation is available at: **https://stef-k.github.io/MauiControlsExtras/**
+
+- [Getting Started](https://stef-k.github.io/MauiControlsExtras/#/quickstart)
+- [Control Documentation](https://stef-k.github.io/MauiControlsExtras/#/controls/combobox)
+- [API Reference](https://stef-k.github.io/MauiControlsExtras/#/api/combobox)
+- [Changelog](https://stef-k.github.io/MauiControlsExtras/#/changelog)
+
+## Contributing
+
+Contributions are welcome! Please see the [Contributing Guide](https://stef-k.github.io/MauiControlsExtras/#/contributing) for guidelines.
 
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-## Documentation
-
-Full documentation is available at: https://stef-k.github.io/MauiControlsExtras/


### PR DESCRIPTION
## Summary

Updates the README to reflect all 16 controls in the library.

## Changes

- Added table listing all 16 controls with descriptions
- Added key features section (cross-platform, keyboard, clipboard, etc.)
- Updated quick start with examples for DataGridView, RichTextEditor, Calendar, TreeView
- Updated requirements to .NET 10.0
- Added links to documentation site sections
- Removed verbose ComboBox-only API reference (now in docs site)