### PR TITLE
fix(DataGridView): resolve rendering bugs preventing grid display

### DIFF
--- a/samples/DemoApp/Views/DataGridDemoPage.xaml
+++ b/samples/DemoApp/Views/DataGridDemoPage.xaml
@@ -55,23 +55,18 @@
 
         <!-- DataGrid -->
         <Frame Grid.Row="2" Style="{StaticResource DemoCardStyle}" Padding="0">
-            <extras:DataGridView ItemsSource="{Binding Employees}"
+            <extras:DataGridView x:Name="dataGrid"
+                                 ItemsSource="{Binding Employees}"
                                  SelectedItem="{Binding SelectedEmployee}"
                                  CanUserSort="{Binding CanUserSort}"
                                  CanUserFilter="{Binding CanUserFilter}"
                                  CanUserEdit="{Binding CanUserEdit}"
                                  EnablePagination="{Binding EnablePagination}"
-                                 SelectionChanged="OnSelectionChanged">
-                <extras:DataGridView.Columns>
-                    <extras:DataGridColumn Header="ID" PropertyName="Id" Width="60" IsReadOnly="True" />
-                    <extras:DataGridColumn Header="Name" PropertyName="Name" Width="150" />
-                    <extras:DataGridComboBoxColumn x:Name="departmentColumn" Header="Department" PropertyName="Department" Width="120" />
-                    <extras:DataGridColumn Header="Salary" PropertyName="Salary" Width="100" StringFormat="${0:N0}" />
-                    <extras:DataGridColumn Header="Hire Date" PropertyName="HireDate" Width="100" StringFormat="{0:d}" />
-                    <extras:DataGridColumn Header="Active" PropertyName="IsActive" Width="70" />
-                    <extras:DataGridColumn Header="Email" PropertyName="Email" Width="200" />
-                </extras:DataGridView.Columns>
-            </extras:DataGridView>
+                                 AutoGenerateColumns="False"
+                                 VerticalOptions="FillAndExpand"
+                                 HorizontalOptions="FillAndExpand"
+                                 MinHeightRequest="300"
+                                 SelectionChanged="OnSelectionChanged" />
         </Frame>
 
         <!-- Status -->

--- a/samples/DemoApp/Views/DataGridDemoPage.xaml.cs
+++ b/samples/DemoApp/Views/DataGridDemoPage.xaml.cs
@@ -1,5 +1,6 @@
 using DemoApp.Models;
 using DemoApp.ViewModels;
+using MauiControlsExtras.Controls;
 
 namespace DemoApp.Views;
 
@@ -8,10 +9,25 @@ public partial class DataGridDemoPage : ContentPage
     public DataGridDemoPage(DataGridDemoViewModel viewModel)
     {
         InitializeComponent();
-        BindingContext = viewModel;
 
-        // Set the department column ItemsSource after initialization
-        departmentColumn.ItemsSource = SampleData.Departments;
+        // Add columns programmatically (XAML column definitions have issues with ContentProperty attribute)
+        var departmentColumn = new DataGridComboBoxColumn
+        {
+            Header = "Department",
+            Binding = "Department",
+            Width = 120,
+            ItemsSource = SampleData.Departments
+        };
+
+        dataGrid.Columns.Add(new DataGridTextColumn { Header = "ID", Binding = "Id", Width = 60, IsReadOnly = true });
+        dataGrid.Columns.Add(new DataGridTextColumn { Header = "Name", Binding = "Name", Width = 150 });
+        dataGrid.Columns.Add(departmentColumn);
+        dataGrid.Columns.Add(new DataGridTextColumn { Header = "Salary", Binding = "Salary", Width = 100, Format = "C0" });
+        dataGrid.Columns.Add(new DataGridTextColumn { Header = "Hire Date", Binding = "HireDate", Width = 100, Format = "d" });
+        dataGrid.Columns.Add(new DataGridCheckBoxColumn { Header = "Active", Binding = "IsActive", Width = 70 });
+        dataGrid.Columns.Add(new DataGridTextColumn { Header = "Email", Binding = "Email", Width = 200 });
+
+        BindingContext = viewModel;
     }
 
     private void OnSelectionChanged(object? sender, object? e)

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml
@@ -6,14 +6,17 @@
                         x:Class="MauiControlsExtras.Controls.DataGridView"
                         x:Name="thisControl">
 
-    <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
+    <base:ListStyledControlBase.Content>
+        <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
             Stroke="{Binding EffectiveBorderColor, Source={x:Reference thisControl}}"
-            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1E1E1E}">
+            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1E1E1E}"
+            VerticalOptions="FillAndExpand"
+            HorizontalOptions="FillAndExpand">
         <Border.StrokeShape>
             <RoundRectangle CornerRadius="{Binding EffectiveCornerRadius, Source={x:Reference thisControl}}" />
         </Border.StrokeShape>
 
-        <Grid RowDefinitions="Auto,*,Auto,Auto">
+        <Grid RowDefinitions="Auto,*,Auto,Auto" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
             <!-- Header Row (combined frozen + scrollable) -->
             <Grid x:Name="headerContainer" Grid.Row="0" ColumnDefinitions="Auto,*">
                 <!-- Frozen Headers -->
@@ -47,7 +50,7 @@
             </Grid>
 
             <!-- Data Rows (combined frozen + scrollable) -->
-            <Grid x:Name="dataContainer" Grid.Row="1" ColumnDefinitions="Auto,*">
+            <Grid x:Name="dataContainer" Grid.Row="1" ColumnDefinitions="Auto,*" VerticalOptions="FillAndExpand">
                 <!-- Frozen Data Columns -->
                 <ScrollView x:Name="frozenDataScrollView"
                             Grid.Column="0"
@@ -72,6 +75,8 @@
                 <ScrollView x:Name="dataScrollView"
                             Grid.Column="1"
                             Orientation="Both"
+                            VerticalOptions="FillAndExpand"
+                            HorizontalOptions="FillAndExpand"
                             Scrolled="OnDataScrollViewScrolled">
                     <Grid x:Name="dataGrid">
                         <!-- Rows are added dynamically -->
@@ -207,4 +212,5 @@
             </Grid>
         </Grid>
     </Border>
+    </base:ListStyledControlBase.Content>
 </base:ListStyledControlBase>

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -2618,7 +2618,6 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
             {
                 Color = Colors.Gray.WithAlpha(0.3f),
                 WidthRequest = 4,
-                HeightRequest = double.PositiveInfinity,
                 VerticalOptions = LayoutOptions.Fill,
                 HorizontalOptions = LayoutOptions.End,
                 Margin = new Thickness(1, 4)


### PR DESCRIPTION
## Summary

- Fix Content property not being set due to ContentProperty attribute conflict by explicitly wrapping Border in `ListStyledControlBase.Content`
- Fix invalid `HeightRequest=Infinity` causing crash on Windows
- Update demo to use programmatic column definitions
- Clean up debug code

## Issues Fixed

- Closes #46 - DataGridView: Content property not set due to ContentProperty attribute conflict
- Closes #47 - DataGridView: Invalid HeightRequest value causes crash on Windows

## Test plan

- [x] DataGridView renders headers and data rows
- [x] No crash on Windows when resizing columns
- [x] Demo app shows employee data correctly