### PR TITLE
fix(DataGridView): use distinct filter icon to avoid confusion with sort

### DIFF
--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -2605,13 +2605,13 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         contentGrid.Children.Add(headerLabel);
         Grid.SetColumn(headerLabel, 0);
 
-        // Filter indicator
+        // Filter indicator (using funnel/filter icon distinct from sort arrows)
         if (CanUserFilter && column.CanUserFilter)
         {
             var filterLabel = new Label
             {
-                Text = column.IsFiltered ? "🔽" : "▽",
-                FontSize = 10,
+                Text = column.IsFiltered ? "⫧" : "⫶",
+                FontSize = 12,
                 VerticalOptions = LayoutOptions.Center,
                 TextColor = column.IsFiltered ? EffectiveAccentColor : Colors.Gray,
                 Margin = new Thickness(4, 0, 0, 0)


### PR DESCRIPTION
## Summary
Change filter indicator icons to be visually distinct from sort arrows.

## Before
- Sort: ▲ / ▼
- Filter: ▽ / 🔽 (similar to sort arrows - confusing)

## After  
- Sort: ▲ / ▼ (unchanged)
- Filter: ⫶ / ⫧ (funnel-style icons - clearly different)

## Test plan
- [ ] Verify filter icon (⫶) is visually distinct from sort arrows
- [ ] Verify active filter shows filled icon (⫧) with accent color

Fixes #63