### PR TITLE
feat(DataGridView): add DatePickerColumn and TimePickerColumn

### DIFF
--- a/docs/api/datagridview.md
+++ b/docs/api/datagridview.md
@@ -209,6 +209,28 @@ public class DataGridComboBoxColumn : DataGridColumn
 }
 ```
 
+### DataGridDatePickerColumn
+
+```csharp
+public class DataGridDatePickerColumn : DataGridColumn
+{
+    string Binding { get; set; }
+    string Format { get; set; }
+    DateTime? MinimumDate { get; set; }
+    DateTime? MaximumDate { get; set; }
+}
+```
+
+### DataGridTimePickerColumn
+
+```csharp
+public class DataGridTimePickerColumn : DataGridColumn
+{
+    string Binding { get; set; }
+    string Format { get; set; }
+}
+```
+
 ## Enumerations
 
 ### DataGridSelectionMode

--- a/docs/controls/datagridview.md
+++ b/docs/controls/datagridview.md
@@ -10,7 +10,7 @@ A feature-rich data grid control for displaying and editing tabular data.
 - **Editing** - In-cell editing with validation
 - **Selection** - Single, multiple, and range selection
 - **Virtual Scrolling** - Efficient handling of large datasets
-- **Column Types** - Text, numeric, checkbox, combo box columns
+- **Column Types** - Text, numeric, checkbox, combo box, date picker, time picker columns
 - **Export** - Export to CSV, TSV, JSON formats
 - **Print** - Print with customizable options
 - **Undo/Redo** - Full undo/redo support for edits
@@ -98,6 +98,26 @@ A feature-rich data grid control for displaying and editing tabular data.
     ItemsSource="{Binding Categories}"
     DisplayMemberPath="Name"
     SelectedValuePath="Id" />
+```
+
+### DataGridDatePickerColumn
+
+```xml
+<extras:DataGridDatePickerColumn
+    Header="Hire Date"
+    Binding="HireDate"
+    Format="d"
+    MinimumDate="2020-01-01"
+    MaximumDate="2030-12-31" />
+```
+
+### DataGridTimePickerColumn
+
+```xml
+<extras:DataGridTimePickerColumn
+    Header="Start Time"
+    Binding="StartTime"
+    Format="t" />
 ```
 
 ## Virtual Scrolling

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridDatePickerColumn.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridDatePickerColumn.cs
@@ -1,0 +1,154 @@
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// DatePicker column for data grid.
+/// </summary>
+public class DataGridDatePickerColumn : DataGridColumn
+{
+    private string _binding = string.Empty;
+    private string? _format;
+    private DateTime? _minimumDate;
+    private DateTime? _maximumDate;
+
+    /// <summary>
+    /// Gets or sets the property binding path.
+    /// </summary>
+    public string Binding
+    {
+        get => _binding;
+        set
+        {
+            if (_binding != value)
+            {
+                _binding = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the date format string (e.g., "d", "D", "yyyy-MM-dd").
+    /// </summary>
+    public string? Format
+    {
+        get => _format;
+        set
+        {
+            if (_format != value)
+            {
+                _format = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the minimum selectable date.
+    /// </summary>
+    public DateTime? MinimumDate
+    {
+        get => _minimumDate;
+        set
+        {
+            if (_minimumDate != value)
+            {
+                _minimumDate = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum selectable date.
+    /// </summary>
+    public DateTime? MaximumDate
+    {
+        get => _maximumDate;
+        set
+        {
+            if (_maximumDate != value)
+            {
+                _maximumDate = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override string? PropertyPath => Binding;
+
+    /// <inheritdoc />
+    public override View CreateCellContent(object item)
+    {
+        var value = GetCellValue(item);
+        var displayText = FormatValue(value);
+
+        return new Label
+        {
+            Text = displayText,
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalTextAlignment = TextAlignment,
+            Padding = new Thickness(8, 4)
+        };
+    }
+
+    /// <inheritdoc />
+    public override View? CreateEditContent(object item)
+    {
+        var value = GetCellValue(item);
+        DateTime date;
+        if (value is DateTime dt)
+            date = dt;
+        else if (value is DateOnly d)
+            date = d.ToDateTime(TimeOnly.MinValue);
+        else
+            date = DateTime.Today;
+
+        var datePicker = new DatePicker
+        {
+            Date = date,
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Fill
+        };
+
+        if (MinimumDate.HasValue)
+            datePicker.MinimumDate = MinimumDate.Value;
+
+        if (MaximumDate.HasValue)
+            datePicker.MaximumDate = MaximumDate.Value;
+
+        return datePicker;
+    }
+
+    /// <summary>
+    /// Gets the value from the edit control.
+    /// </summary>
+    public DateTime GetValueFromEditControl(View editControl)
+    {
+        if (editControl is DatePicker datePicker)
+        {
+            return datePicker.Date ?? DateTime.Today;
+        }
+        return DateTime.Today;
+    }
+
+    private string FormatValue(object? value)
+    {
+        if (value == null)
+            return string.Empty;
+
+        DateTime? date = null;
+        if (value is DateTime dateTime)
+            date = dateTime;
+        else if (value is DateOnly dateOnly)
+            date = dateOnly.ToDateTime(TimeOnly.MinValue);
+
+        if (date == null)
+            return value.ToString() ?? string.Empty;
+
+        if (!string.IsNullOrEmpty(Format))
+            return date.Value.ToString(Format);
+
+        return date.Value.ToShortDateString();
+    }
+}

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridTimePickerColumn.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridTimePickerColumn.cs
@@ -1,0 +1,124 @@
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// TimePicker column for data grid.
+/// </summary>
+public class DataGridTimePickerColumn : DataGridColumn
+{
+    private string _binding = string.Empty;
+    private string? _format;
+
+    /// <summary>
+    /// Gets or sets the property binding path.
+    /// </summary>
+    public string Binding
+    {
+        get => _binding;
+        set
+        {
+            if (_binding != value)
+            {
+                _binding = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the time format string (e.g., "t", "T", "HH:mm").
+    /// </summary>
+    public string? Format
+    {
+        get => _format;
+        set
+        {
+            if (_format != value)
+            {
+                _format = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override string? PropertyPath => Binding;
+
+    /// <inheritdoc />
+    public override View CreateCellContent(object item)
+    {
+        var value = GetCellValue(item);
+        var displayText = FormatValue(value);
+
+        return new Label
+        {
+            Text = displayText,
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalTextAlignment = TextAlignment,
+            Padding = new Thickness(8, 4)
+        };
+    }
+
+    /// <inheritdoc />
+    public override View? CreateEditContent(object item)
+    {
+        var value = GetCellValue(item);
+        TimeSpan time;
+        if (value is TimeSpan ts)
+            time = ts;
+        else if (value is TimeOnly t)
+            time = t.ToTimeSpan();
+        else if (value is DateTime dateTime)
+            time = dateTime.TimeOfDay;
+        else
+            time = TimeSpan.Zero;
+
+        var timePicker = new TimePicker
+        {
+            Time = time,
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Fill
+        };
+
+        return timePicker;
+    }
+
+    /// <summary>
+    /// Gets the value from the edit control.
+    /// </summary>
+    public TimeSpan GetValueFromEditControl(View editControl)
+    {
+        if (editControl is TimePicker timePicker)
+        {
+            return timePicker.Time ?? TimeSpan.Zero;
+        }
+        return TimeSpan.Zero;
+    }
+
+    private string FormatValue(object? value)
+    {
+        if (value == null)
+            return string.Empty;
+
+        TimeSpan? time = null;
+        if (value is TimeSpan ts)
+            time = ts;
+        else if (value is TimeOnly t)
+            time = t.ToTimeSpan();
+        else if (value is DateTime dateTime)
+            time = dateTime.TimeOfDay;
+
+        if (time == null)
+            return value.ToString() ?? string.Empty;
+
+        if (!string.IsNullOrEmpty(Format))
+        {
+            // TimeSpan doesn't support format strings directly, convert to DateTime
+            var formatted = DateTime.Today.Add(time.Value);
+            return formatted.ToString(Format);
+        }
+
+        // Default short time format
+        var defaultFormatted = DateTime.Today.Add(time.Value);
+        return defaultFormatted.ToShortTimeString();
+    }
+}

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -3687,6 +3687,8 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
             Entry entry => entry.Text,
             CheckBox checkBox => checkBox.IsChecked,
             Picker picker when column is DataGridComboBoxColumn comboColumn => comboColumn.GetValueFromEditControl(control),
+            DatePicker datePicker when column is DataGridDatePickerColumn dateColumn => dateColumn.GetValueFromEditControl(control),
+            TimePicker timePicker when column is DataGridTimePickerColumn timeColumn => timeColumn.GetValueFromEditControl(control),
             _ => null
         };
     }


### PR DESCRIPTION
## Summary
Add new column types for editing date and time values with native picker controls.

## New Column Types

### DataGridDatePickerColumn
- Native DatePicker control for editing
- Supports `DateTime` and `DateOnly` property types
- Properties: `Binding`, `Format`, `MinimumDate`, `MaximumDate`

### DataGridTimePickerColumn  
- Native TimePicker control for editing
- Supports `TimeSpan`, `TimeOnly`, and `DateTime.TimeOfDay` property types
- Properties: `Binding`, `Format`

## Usage

```xml
<extras:DataGridDatePickerColumn
    Header="Hire Date"
    Binding="HireDate"
    Format="d" />

<extras:DataGridTimePickerColumn
    Header="Start Time"  
    Binding="StartTime"
    Format="t" />
```

## Documentation Updated
- API reference (docs/api/datagridview.md)
- Controls guide (docs/controls/datagridview.md)

## Test plan
- [ ] Add DatePickerColumn to demo - verify date display and editing
- [ ] Add TimePickerColumn to demo - verify time display and editing
- [ ] Verify Format property works for both column types

Fixes #61
Fixes #62