### PR TITLE
fix(DataGridView): sort indicator visibility and ESC key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,16 @@ xmlns:extras="clr-namespace:MauiControlsExtras.Controls;assembly=MauiControlsExt
                  DisplayMemberPath="Name"
                  Placeholder="Select a country..." />
 
-<!-- DataGrid with sorting and filtering -->
+<!-- DataGrid with sorting, filtering, and various column types -->
 <extras:DataGridView ItemsSource="{Binding Employees}"
                      CanUserEdit="True"
-                     EnableSorting="True"
-                     EnableFiltering="True">
+                     CanUserSort="True"
+                     CanUserFilter="True">
     <extras:DataGridView.Columns>
         <extras:DataGridTextColumn Header="Name" Binding="Name" />
-        <extras:DataGridTextColumn Header="Department" Binding="Department" />
-        <extras:DataGridNumericColumn Header="Salary" Binding="Salary" Format="C0" />
+        <extras:DataGridTextColumn Header="Salary" Binding="Salary" Format="C0" />
+        <extras:DataGridDatePickerColumn Header="Hire Date" Binding="HireDate" Format="d" />
+        <extras:DataGridCheckBoxColumn Header="Active" Binding="IsActive" />
     </extras:DataGridView.Columns>
 </extras:DataGridView>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DataGridView**: DatePickerColumn for date editing with native DatePicker (#61)
+- **DataGridView**: TimePickerColumn for time editing with native TimePicker (#62)
+- **DataGridView**: Sort indicator (⇅) visible when column is sortable (#69)
+- **DataGridView**: ESC key cancels edit on Windows desktop (#68)
 - **RichTextEditor**: Dark theme support with dynamic switching (#40)
 - **RichTextEditor**: Local/bundled Quill.js support for offline use (#37)
 - **Calendar**: Date picker control with single, multiple, and range selection (#16)
@@ -34,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **DataGridView**: Filter icon now distinct from sort arrows (⫶ vs ▲/▼) (#63)
+- **DataGridView**: Feature toggle checkboxes now update UI correctly (#64)
+- **DataGridView**: Selection performance with targeted visual updates (#52, #58)
+- **DataGridView**: Edit trigger default and dark theme text contrast (#57, #59)
+- **DataGridView**: Type conversion when committing cell edits (#55)
 - Documentation GitHub Pages deployment with .nojekyll file (#35)
 
 ## [1.0.0] - Initial Release

--- a/samples/DemoApp/Views/DataGridDemoPage.xaml.cs
+++ b/samples/DemoApp/Views/DataGridDemoPage.xaml.cs
@@ -23,7 +23,7 @@ public partial class DataGridDemoPage : ContentPage
         dataGrid.Columns.Add(new DataGridTextColumn { Header = "Name", Binding = "Name", Width = 150 });
         dataGrid.Columns.Add(departmentColumn);
         dataGrid.Columns.Add(new DataGridTextColumn { Header = "Salary", Binding = "Salary", Width = 100, Format = "C0" });
-        dataGrid.Columns.Add(new DataGridTextColumn { Header = "Hire Date", Binding = "HireDate", Width = 100, Format = "d" });
+        dataGrid.Columns.Add(new DataGridDatePickerColumn { Header = "Hire Date", Binding = "HireDate", Width = 120, Format = "d" });
         dataGrid.Columns.Add(new DataGridCheckBoxColumn { Header = "Active", Binding = "IsActive", Width = 70 });
         dataGrid.Columns.Add(new DataGridTextColumn { Header = "Email", Binding = "Email", Width = 200 });
 


### PR DESCRIPTION
## Summary
Multiple improvements to DataGridView:

### Framework Fixes
- **Sort Indicator (#69)**: Show sortable indicator (⇅) when `CanUserSort` is true, changes to ▲/▼ when sorted
- **ESC Key (#68)**: Cancel edit when ESC pressed on Windows desktop
- **Edit Controls**: Add Unfocused handlers for DatePicker/TimePicker

### Demo App
- Update HireDate column to use `DataGridDatePickerColumn`

### Documentation
- Update README with new column types example
- Update changelog with all recent features and fixes

## Test plan
- [ ] Verify sort indicator (⇅) shows on sortable columns
- [ ] Click column header - verify ▲ shows for ascending sort
- [ ] Press ESC while editing on Windows - verify edit is cancelled
- [ ] Verify HireDate column shows DatePicker when editing

Fixes #68
Fixes #69