### PR TITLE
fix(DataGridView): wire up keyboard behavior for F2 and other keys

### DIFF
--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Windows.Input;
 using MauiControlsExtras.Base;
 using MauiControlsExtras.Base.Validation;
+using MauiControlsExtras.Behaviors;
 
 namespace MauiControlsExtras.Controls;
 
@@ -1415,6 +1416,9 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         // Set initial page size picker
         pageSizePicker.SelectedIndex = 2; // 50
+
+        // Attach keyboard behavior for desktop keyboard handling (F2, arrow keys, etc.)
+        Behaviors.Add(new KeyboardBehavior { HandleTabKey = true });
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Attaches `KeyboardBehavior` to the DataGridView in constructor
- This enables F2 key to enter edit mode on desktop platforms
- The existing `HandleF2Key()` implementation was never being called because the behavior was not attached

## Test plan
- [ ] Run the demo app on Windows
- [ ] Select a cell in the DataGrid
- [ ] Press F2 - should enter edit mode
- [ ] Press ESC - should cancel edit

Closes #74