### PR TITLE
fix(DataGridView): focus grid on cell tap to enable keyboard shortcuts

### DIFF
--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -4443,6 +4443,9 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         SelectItem(item);
         _focusedColumnIndex = colIndex;
 
+        // Focus the grid to enable keyboard shortcuts (F2, ESC, arrow keys, etc.)
+        this.Focus();
+
         var args = new DataGridCellEventArgs(item, column, rowIndex, colIndex);
         CellTapped?.Invoke(this, args);
 


### PR DESCRIPTION
## Summary
- Calls `this.Focus()` in `OnCellTapped` to give the DataGridView keyboard focus

## Problem
After clicking a cell, F2 and other keyboard shortcuts didn't work because the grid didn't have keyboard focus. The KeyboardBehavior only receives events when its attached view has focus.

## Solution
Simply call `this.Focus()` after a cell tap to ensure the grid receives keyboard focus.

## Test plan
- [ ] Click on a cell in the DataGrid
- [ ] Press F2 - should enter edit mode
- [ ] Press ESC - should cancel edit (if in edit mode)
- [ ] Use arrow keys - should navigate between cells

Closes #80