### PR TITLE
feat(DataGridView): use library ComboBox control for ComboBoxColumn

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,7 @@ MauiControlsExtras provides custom controls for .NET MAUI applications, designed
 - **MVVM Support**: Every user action has both an event and a corresponding command
 - **Theme Integration**: Controls respect global themes while allowing per-instance customization
 - **Optional Behaviors**: Interface-based patterns for validation, clipboard, selection, and undo/redo
+- **Internal Reuse**: When a library control can fulfill a need, prefer it over standard MAUI controls (e.g., DataGridComboBoxColumn uses our ComboBox, not MAUI Picker)
 
 ## Project Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All controls now support keyboard navigation (#27)
 - All controls now support mouse interactions (#27)
+- **DataGridView**: ComboBoxColumn now uses library's ComboBox control with search/filtering support (#82)
 
 ### Fixed
 

--- a/docs/api/datagridview.md
+++ b/docs/api/datagridview.md
@@ -200,14 +200,24 @@ public class DataGridCheckBoxColumn : DataGridColumn
 
 ### DataGridComboBoxColumn
 
+Uses the library's custom ComboBox control with search/filtering support.
+
 ```csharp
 public class DataGridComboBoxColumn : DataGridColumn
 {
-    IEnumerable ItemsSource { get; set; }
-    string DisplayMemberPath { get; set; }
-    string SelectedValuePath { get; set; }
+    string Binding { get; set; }              // Property path for selected value
+    IEnumerable ItemsSource { get; set; }     // Dropdown items collection
+    string DisplayMemberPath { get; set; }    // Property to display in dropdown
+    string SelectedValuePath { get; set; }    // Property for selected value
+    string Placeholder { get; set; }          // Search placeholder text (default: "Select...")
+    int VisibleItemCount { get; set; }        // Visible items in dropdown (default: 6)
 }
 ```
+
+**Features:**
+- Built-in search/filtering of dropdown items
+- Keyboard navigation support
+- Theme-aware styling
 
 ### DataGridDatePickerColumn
 

--- a/docs/controls/datagridview.md
+++ b/docs/controls/datagridview.md
@@ -91,14 +91,24 @@ A feature-rich data grid control for displaying and editing tabular data.
 
 ### DataGridComboBoxColumn
 
+Uses the library's custom ComboBox control with built-in search/filtering support.
+
 ```xml
 <extras:DataGridComboBoxColumn
     Header="Category"
     Binding="CategoryId"
     ItemsSource="{Binding Categories}"
     DisplayMemberPath="Name"
-    SelectedValuePath="Id" />
+    SelectedValuePath="Id"
+    Placeholder="Search categories..."
+    VisibleItemCount="8" />
 ```
+
+**Features:**
+- Search/filter dropdown items by typing
+- Keyboard navigation (↑/↓/Enter/Escape/Home/End)
+- Customizable placeholder text
+- Configurable visible item count
 
 ### DataGridDatePickerColumn
 

--- a/samples/DemoApp/Views/DataGridDemoPage.xaml.cs
+++ b/samples/DemoApp/Views/DataGridDemoPage.xaml.cs
@@ -11,12 +11,14 @@ public partial class DataGridDemoPage : ContentPage
         InitializeComponent();
 
         // Add columns programmatically (XAML column definitions have issues with ContentProperty attribute)
+        // ComboBox column now uses the library's ComboBox control with search/filtering support
         var departmentColumn = new DataGridComboBoxColumn
         {
             Header = "Department",
             Binding = "Department",
-            Width = 120,
-            ItemsSource = SampleData.Departments
+            Width = 150,
+            ItemsSource = SampleData.Departments,
+            Placeholder = "Search departments..."
         };
 
         dataGrid.Columns.Add(new DataGridTextColumn { Header = "ID", Binding = "Id", Width = 60, IsReadOnly = true });


### PR DESCRIPTION
## Summary
Replaces standard MAUI Picker with library's custom ComboBox control in DataGridComboBoxColumn.

## Changes
- **DataGridComboBoxColumn**: Now uses `ComboBox` control for editing
- **DataGridView**: Added ComboBox event handling (`SelectionChanged`)
- **New Properties**:
  - `Placeholder`: Search placeholder text (default: "Select...")
  - `VisibleItemCount`: Number of visible dropdown items (default: 6)

## Benefits
- **Search/filtering**: Type to filter dropdown items
- **Keyboard navigation**: ↑/↓/Enter/Escape/Home/End
- **Consistent UX**: Same control behavior as standalone ComboBox
- **Theme-aware**: Proper light/dark mode styling

## Design Principle
Added to ARCHITECTURE.md: "When a library control can fulfill a need, prefer it over standard MAUI controls"

## Documentation Updated
- `docs/controls/datagridview.md` - Added filtering feature description
- `docs/api/datagridview.md` - Updated column properties
- `ARCHITECTURE.md` - Added internal reuse principle
- `CHANGELOG.md` - Added feature entry

## Test plan
- [ ] Double-click on Department column in demo DataGrid
- [ ] Type to filter departments
- [ ] Use arrow keys to navigate, Enter to select
- [ ] Press Escape to cancel edit
- [ ] Verify selection commits properly

Closes #82