### PR TITLE
fix(DataGridView): ComboBox auto-open and right-click context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DataGridView**: Type conversion when committing cell edits (#55)
 - **DataGridView**: Picker/DatePicker/TimePicker columns now stay open when dropdown opens (#77)
 - **DataGridView**: F2/ESC/arrow keys now work after cell tap (grid receives focus) (#80)
+- **DataGridView**: ComboBox column now auto-opens dropdown when entering edit mode (#84)
+- **DataGridView**: Right-click context menu now works on Windows desktop (#85)
 - Documentation GitHub Pages deployment with .nojekyll file (#35)
 
 ## [1.0.0] - Initial Release


### PR DESCRIPTION
## Summary
Fixes two framework issues in the DataGridView.

## Issue #84: ComboBox column dropdown not visible
**Problem**: When editing a ComboBox column, only the collapsed view was shown - dropdown list was not visible.

**Solution**: Auto-open the ComboBox dropdown when entering edit mode:
```csharp
Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(100), () =>
{
    if (_editingItem != null)
    {
        comboBox.Open();
    }
});
```

## Issue #85: Right-click context menu not working
**Problem**: The PointerPressed handler was empty and didn't call ShowContextMenu.

**Solution**: Replaced with TapGestureRecognizer using ButtonsMask.Secondary:
```csharp
var rightClickGesture = new TapGestureRecognizer { Buttons = ButtonsMask.Secondary };
rightClickGesture.Tapped += (s, e) => ShowContextMenu(item, column, rowIndex, colIndex);
```

## Test plan
- [ ] Double-click on Department column - dropdown should auto-open
- [ ] Type to filter departments
- [ ] Right-click on any cell - context menu should appear
- [ ] Context menu options (Copy, Cut, Paste, etc.) should work

Closes #84, closes #85