### PR TITLE
fix(DataGrid): context menu native handlers + ComboBox Picker fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All controls now support keyboard navigation (#27)
 - All controls now support mouse interactions (#27)
-- **DataGridView**: ComboBoxColumn now uses library's ComboBox control with search/filtering support (#82)
 
 ### Fixed
 
@@ -47,8 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DataGridView**: Type conversion when committing cell edits (#55)
 - **DataGridView**: Picker/DatePicker/TimePicker columns now stay open when dropdown opens (#77)
 - **DataGridView**: F2/ESC/arrow keys now work after cell tap (grid receives focus) (#80)
-- **DataGridView**: ComboBox column now auto-opens dropdown when entering edit mode (#84)
-- **DataGridView**: Right-click context menu now works on Windows desktop (#85)
+- **DataGridView**: Right-click context menu now works on Windows desktop using native handlers (#85)
+
+### Known Issues
+
+- **DataGridView**: ComboBoxColumn uses native Picker instead of library's ComboBox due to dropdown clipping within cell bounds. Popup-based ComboBox with filtering support planned for future release (#87)
 - Documentation GitHub Pages deployment with .nojekyll file (#35)
 
 ## [1.0.0] - Initial Release


### PR DESCRIPTION
## Summary

- **Context menu**: Fixed right-click context menu on Windows desktop by using native `RightTapped` handler instead of `ButtonsMask.Secondary` (workaround for MAUI bug #24734)
- **ComboBoxColumn**: Reverted to standard MAUI Picker due to dropdown clipping within cell bounds. The library's ComboBox uses inline layout where the dropdown gets clipped by the parent container.

## Related Issues

- Fixes #85 (context menu)
- Relates to #87 (popup-based ComboBox - future enhancement)

## Technical Details

### Context Menu Fix
The `TapGestureRecognizer.ButtonsMask.Secondary` approach doesn't work due to MAUI bug #24734 where ButtonsMask always returns 0. Solution uses Windows-native `RightTapped` event via `HandlerChanged`:

```csharp
#if WINDOWS
container.HandlerChanged += (s, e) =>
{
    if (container.Handler?.PlatformView is Microsoft.UI.Xaml.FrameworkElement element)
    {
        element.RightTapped += (sender, args) =>
        {
            args.Handled = true;
            Dispatcher.Dispatch(() => ShowContextMenu(item, column, rowIndex, colIndex));
        };
    }
};
#endif
```

### ComboBox Limitation
The library's ComboBox uses an inline Grid layout where the dropdown occupies Row 1. When rendered inside a DataGrid cell, the dropdown is clipped by the cell's bounds. Issue #87 tracks implementing a popup-based approach that can render outside the cell bounds.

## Test plan

- [ ] Right-click on a cell in DataGridView on Windows - context menu should appear
- [ ] ComboBox column should display and work (using native Picker dropdown)
- [ ] Verify no regression in other DataGrid edit features (text, date, time, checkbox)