### PR TITLE
docs: fix TreeView CheckBoxMode property naming

### DIFF
--- a/docs/controls/treeview.md
+++ b/docs/controls/treeview.md
@@ -48,8 +48,13 @@ public class TreeNode
     ItemsSource="{Binding RootNodes}"
     ShowCheckBoxes="True"
     CheckedItems="{Binding CheckedItems}"
-    AllowTriStateCheckBoxes="True" />
+    CheckBoxMode="TriState" />
 ```
+
+**CheckBoxMode values:**
+- `Independent` - Checkboxes are independent (default)
+- `Cascade` - Checking parent checks all children
+- `TriState` - Parent shows indeterminate state when some children are checked
 
 ## Selection
 
@@ -103,5 +108,5 @@ public class TreeNode
 | DisplayMemberPath | string | Property to display |
 | SelectedItem | object | Currently selected node |
 | ShowCheckBoxes | bool | Show checkboxes |
-| AllowTriStateCheckBoxes | bool | Enable tri-state checkboxes |
+| CheckBoxMode | CheckBoxMode | Checkbox behavior: Independent, Cascade, or TriState |
 | SelectionMode | SelectionMode | Single or Multiple |


### PR DESCRIPTION
## Summary

- Fix incorrect `AllowTriStateCheckBoxes` property reference (doesn't exist) to actual `CheckBoxMode` enum
- Update XAML example to use `CheckBoxMode="TriState"`
- Update properties table with correct type and description
- Add explanation of CheckBoxMode values (Independent, Cascade, TriState)

Fixes #118

## Test plan

- [ ] Verify documentation renders correctly
- [ ] Confirm XAML example matches actual TreeView API