### PR TITLE
docs: add keyboard shortcuts section to ComboBox documentation

### DIFF
--- a/docs/controls/combobox.md
+++ b/docs/controls/combobox.md
@@ -226,6 +226,21 @@ private void ComboBox_Closed(object sender, EventArgs e)
 }
 ```
 
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| ↓ (Down) | Open dropdown / Move to next item |
+| ↑ (Up) | Move to previous item |
+| Enter | Select highlighted item / Open dropdown |
+| Space | Open dropdown |
+| Escape | Close dropdown |
+| Home | Move to first item |
+| End | Move to last item |
+| Tab | Select filtered/highlighted item (Windows only) |
+
+> **Note:** Tab autocomplete selects the single filtered result, or the currently highlighted item if multiple results exist. This behavior is currently Windows-only.
+
 ## Styling
 
 The ComboBox automatically adapts to light/dark themes. Key colors:


### PR DESCRIPTION
## Summary

- Add new Keyboard Shortcuts section to ComboBox documentation
- Document all keyboard navigation shortcuts (Down, Up, Enter, Space, Escape, Home, End)
- Document Tab key autocomplete feature with Windows-only note

Closes #100

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm shortcuts match implementation in `ComboBox.xaml.cs`