### PR TITLE
docs: fix AccentColor property documentation (Issue #94)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,7 +79,7 @@ All controls inherit these core properties:
 
 ```csharp
 // Colors
-AccentColor         // Primary accent (default: #0078D4)
+AccentColor         // Primary accent (default: null, uses theme)
 ForegroundColor     // Text/icon color (theme-aware)
 DisabledColor       // Disabled state color
 ErrorColor          // Validation error color (#D32F2F)

--- a/docs/api/combobox.md
+++ b/docs/api/combobox.md
@@ -144,15 +144,15 @@ public int VisibleItemCount { get; set; }
 
 ### AccentColor
 
-Gets or sets the accent color used for focus indication.
+Gets or sets the accent color used for focus indication. When `null`, falls back to the theme's accent color.
 
 ```csharp
-public Color AccentColor { get; set; }
+public Color? AccentColor { get; set; }
 ```
 
 | Type | Default | Bindable |
 |------|---------|----------|
-| `Color` | `#0078D4` | Yes |
+| `Color?` | `null` (theme default) | Yes |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixed `AccentColor` property documentation to reflect actual implementation
- Type corrected from `Color` to `Color?` (nullable)
- Default value corrected from `#0078D4` to `null (theme default)`
- Added description of fallback behavior to theme's accent color

## Files Changed
- `docs/api/combobox.md` - Updated AccentColor property section
- `ARCHITECTURE.md` - Updated AccentColor comment

## Test plan
- [x] Verified changes match actual implementation in `StyledControlBase.cs`
- [x] Confirmed documentation accurately describes nullable type and fallback behavior

Fixes #94