### PR TITLE
docs: fix Rating control property names in documentation

### DIFF
--- a/docs/controls/rating.md
+++ b/docs/controls/rating.md
@@ -4,10 +4,10 @@ A star/icon-based rating control.
 
 ## Features
 
-- **Configurable Rating** - Set min, max, and step values
-- **Custom Icons** - Use any icon or symbol
+- **Configurable Rating** - Set maximum value and precision mode
+- **Custom Icons** - Choose from Star, Heart, Circle, or Thumb icons
 - **Read-Only Mode** - Display ratings without interaction
-- **Half Stars** - Support for fractional ratings
+- **Precision Modes** - Support for full, half, or exact ratings
 - **Keyboard Navigation** - Full keyboard support
 
 ## Basic Usage
@@ -18,24 +18,60 @@ A star/icon-based rating control.
     Maximum="5" />
 ```
 
-## Half Star Ratings
+## Precision Modes
+
+The `Precision` property controls the rating granularity:
+
+### Full Precision (Default)
+
+Only whole numbers (1, 2, 3, etc.):
 
 ```xml
 <extras:Rating
     Value="{Binding Rating}"
     Maximum="5"
-    Step="0.5"
-    AllowHalfStars="True" />
+    Precision="Full" />
 ```
 
-## Custom Icons
+### Half Precision
+
+Whole and half values (1, 1.5, 2, 2.5, etc.):
 
 ```xml
 <extras:Rating
     Value="{Binding Rating}"
-    EmptyIcon="&#xE734;"
-    FilledIcon="&#xE735;"
-    IconFontFamily="Segoe MDL2 Assets" />
+    Maximum="5"
+    Precision="Half" />
+```
+
+### Exact Precision
+
+Any decimal value (useful for displaying averages):
+
+```xml
+<extras:Rating
+    Value="{Binding AverageRating}"
+    Maximum="5"
+    Precision="Exact"
+    IsReadOnly="True" />
+```
+
+## Custom Icons
+
+Use the `Icon` property to choose from built-in icon types:
+
+```xml
+<!-- Star icons (default) -->
+<extras:Rating Value="{Binding Rating}" Icon="Star" />
+
+<!-- Heart icons -->
+<extras:Rating Value="{Binding Rating}" Icon="Heart" />
+
+<!-- Circle icons -->
+<extras:Rating Value="{Binding Rating}" Icon="Circle" />
+
+<!-- Thumbs up icons -->
+<extras:Rating Value="{Binding Rating}" Icon="Thumb" />
 ```
 
 ## Read-Only Display
@@ -57,13 +93,23 @@ A star/icon-based rating control.
     Spacing="8" />
 ```
 
+## Allow Clear
+
+By default, tapping the current rating value clears it to 0. Disable this behavior:
+
+```xml
+<extras:Rating
+    Value="{Binding Rating}"
+    AllowClear="False" />
+```
+
 ## Keyboard Shortcuts
 
 | Key | Action |
 |-----|--------|
-| ← | Decrease rating |
-| → | Increase rating |
-| Home | Set to minimum |
+| ← / ↓ | Decrease rating |
+| → / ↑ | Increase rating |
+| Home / Delete | Clear rating (set to 0) |
 | End | Set to maximum |
 | 1-5 | Set specific value |
 
@@ -72,26 +118,58 @@ A star/icon-based rating control.
 | Event | Description |
 |-------|-------------|
 | ValueChanged | Rating value changed |
+| Cleared | Rating was cleared to 0 |
+| ValidationChanged | Validation state changed |
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | ValueChangedCommand | Execute when rating changes |
+| ClearedCommand | Execute when rating is cleared |
 
 ## Properties
 
-| Property | Type | Description |
-|----------|------|-------------|
-| Value | double | Current rating value |
-| Minimum | double | Minimum rating (default: 0) |
-| Maximum | double | Maximum rating (default: 5) |
-| Step | double | Rating increment (default: 1) |
-| AllowHalfStars | bool | Allow fractional values |
-| IsReadOnly | bool | Disable interaction |
-| FilledColor | Color | Color of filled stars |
-| EmptyColor | Color | Color of empty stars |
-| IconSize | double | Size of rating icons |
-| Spacing | double | Space between icons |
-| EmptyIcon | string | Icon for empty state |
-| FilledIcon | string | Icon for filled state |
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| Value | double | 0 | Current rating value |
+| Maximum | int | 5 | Maximum rating (number of icons) |
+| Precision | RatingPrecision | Full | Rating granularity mode |
+| Icon | RatingIcon | Star | Icon type to display |
+| IsReadOnly | bool | false | Disable interaction |
+| AllowClear | bool | true | Allow tapping same value to clear |
+| FilledColor | Color | #FFD700 | Color of filled icons |
+| EmptyColor | Color | #E0E0E0 | Color of empty icons |
+| IconSize | double | 32 | Size of rating icons |
+| Spacing | double | 4 | Space between icons |
+
+## Enums
+
+### RatingPrecision
+
+| Value | Description |
+|-------|-------------|
+| Full | Only whole numbers (1, 2, 3, etc.) |
+| Half | Whole and half values (1, 1.5, 2, 2.5, etc.) |
+| Exact | Any decimal value (display only, for averages) |
+
+### RatingIcon
+
+| Value | Description |
+|-------|-------------|
+| Star | Star icon (★/☆) - default |
+| Heart | Heart icon (♥/♡) |
+| Circle | Circle icon (●/○) |
+| Thumb | Thumbs up icon (👍) |
+
+## Validation Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| IsRequired | bool | false | Whether a rating is required |
+| RequiredErrorMessage | string | "A rating is required." | Error message when required but not provided |
+| MinimumValue | double? | null | Minimum required value for validation |
+| MinimumValueErrorMessage | string | "Rating must be at least {0}." | Error message when below minimum |
+| IsValid | bool | true | Whether current value passes validation |
+| ValidationErrors | IReadOnlyList\<string\> | - | List of current validation errors |
+| ValidateCommand | ICommand | null | Command executed when validation is triggered |


### PR DESCRIPTION
## Summary

- Fix incorrect property names that don't exist in the actual implementation
- Add missing properties and enum documentation
- Add validation properties section

## Changes

| Documented (Wrong) | Actual Property |
|--------------------|-----------------|
| `AllowHalfStars` | `Precision` enum |
| `Step` | Removed (use `Precision`) |
| `EmptyIcon`/`FilledIcon` | `Icon` enum |
| `IconFontFamily` | Removed |
| `Minimum` | Removed |

**Added:**
- `AllowClear` property documentation
- `RatingPrecision` enum values (Full, Half, Exact)
- `RatingIcon` enum values (Star, Heart, Circle, Thumb)
- Validation properties section

Fixes #115

## Test plan

- [x] Verify all property names match source code
- [x] Verify code examples use correct syntax
- [x] Verify default values match source code