### PR TITLE
docs: document IValidatable interface across controls

### DIFF
--- a/docs/api/interfaces.md
+++ b/docs/api/interfaces.md
@@ -236,7 +236,6 @@ Interface for controls that support validation.
 public interface IValidatable
 {
     // Properties
-    bool IsRequired { get; set; }
     bool IsValid { get; }
     IReadOnlyList<string> ValidationErrors { get; }
 
@@ -246,6 +245,70 @@ public interface IValidatable
     // Commands
     ICommand? ValidateCommand { get; set; }
 }
+```
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| IsValid | bool | Whether the current value passes all validation rules |
+| ValidationErrors | IReadOnlyList&lt;string&gt; | List of current validation error messages |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| Validate() | ValidationResult | Performs validation and returns the result |
+
+### Commands
+
+| Command | Parameter | Description |
+|---------|-----------|-------------|
+| ValidateCommand | ValidationResult | Executed after validation completes |
+
+### Common Validation Properties
+
+Controls implementing `IValidatable` typically also provide these properties (not part of the interface):
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| IsRequired | bool | false | Whether a value is required |
+| RequiredErrorMessage | string | varies | Error message when required validation fails |
+
+### Controls Implementing IValidatable
+
+- ComboBox
+- MaskedEntry
+- MultiSelectComboBox
+- NumericUpDown
+- RangeSlider
+- Rating
+- TokenEntry
+
+### Usage Example
+
+```csharp
+// Check validation state
+if (!myControl.IsValid)
+{
+    foreach (var error in myControl.ValidationErrors)
+    {
+        Debug.WriteLine(error);
+    }
+}
+
+// Trigger validation manually
+var result = myControl.Validate();
+if (!result.IsValid)
+{
+    DisplayErrors(result.Errors);
+}
+
+// Use ValidateCommand for MVVM
+<extras:NumericUpDown
+    Value="{Binding Quantity}"
+    IsRequired="True"
+    ValidateCommand="{Binding OnValidationCommand}" />
 ```
 
 ---

--- a/docs/controls/combobox.md
+++ b/docs/controls/combobox.md
@@ -253,6 +253,50 @@ The ComboBox automatically adapts to light/dark themes. Key colors:
 | Placeholder | #6B7280 | #9CA3AF |
 | Focus Border | AccentColor | AccentColor |
 
+## Validation
+
+ComboBox implements `IValidatable` for built-in validation support.
+
+```xml
+<extras:ComboBox
+    ItemsSource="{Binding Items}"
+    SelectedItem="{Binding SelectedItem}"
+    IsRequired="True"
+    RequiredErrorMessage="Please select an item"
+    ValidateCommand="{Binding OnValidationCommand}" />
+```
+
+### Checking Validation State
+
+```csharp
+if (!comboBox.IsValid)
+{
+    foreach (var error in comboBox.ValidationErrors)
+    {
+        Debug.WriteLine(error);
+    }
+}
+
+// Trigger validation manually
+var result = comboBox.Validate();
+```
+
+### Validation Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| IsRequired | bool | false | Whether a selection is required |
+| RequiredErrorMessage | string | "This field is required." | Error message when required but nothing selected |
+| IsValid | bool | (read-only) | Current validation state |
+| ValidationErrors | IReadOnlyList&lt;string&gt; | (read-only) | List of validation error messages |
+| ValidateCommand | ICommand | null | Command executed when validation occurs |
+
+### Events
+
+| Event | Description |
+|-------|-------------|
+| ValidationChanged | Fired when IsValid state changes |
+
 ## Best Practices
 
 1. **Use DisplayMemberPath** for complex objects instead of overriding ToString()

--- a/docs/controls/multiselectcombobox.md
+++ b/docs/controls/multiselectcombobox.md
@@ -76,6 +76,44 @@ A dropdown control that allows selecting multiple items with checkboxes.
 | DropdownOpened | Dropdown was opened |
 | DropdownClosed | Dropdown was closed |
 
+## Validation
+
+MultiSelectComboBox implements `IValidatable` for built-in validation support.
+
+```xml
+<extras:MultiSelectComboBox
+    ItemsSource="{Binding Categories}"
+    SelectedItems="{Binding SelectedCategories}"
+    IsRequired="True"
+    RequiredErrorMessage="Please select at least one category"
+    ValidateCommand="{Binding OnValidationCommand}" />
+```
+
+### Checking Validation State
+
+```csharp
+if (!multiSelectComboBox.IsValid)
+{
+    foreach (var error in multiSelectComboBox.ValidationErrors)
+    {
+        Debug.WriteLine(error);
+    }
+}
+
+// Trigger validation manually
+var result = multiSelectComboBox.Validate();
+```
+
+### Validation Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| IsRequired | bool | false | Whether at least one selection is required |
+| RequiredErrorMessage | string | "This field is required." | Error message when required but nothing selected |
+| IsValid | bool | (read-only) | Current validation state |
+| ValidationErrors | IReadOnlyList&lt;string&gt; | (read-only) | List of validation error messages |
+| ValidateCommand | ICommand | null | Command executed when validation occurs |
+
 ## Properties
 
 | Property | Type | Description |

--- a/docs/controls/numericupdown.md
+++ b/docs/controls/numericupdown.md
@@ -115,7 +115,7 @@ Display placeholder text when the value is null:
 
 ## Validation
 
-The control supports validation through `IsRequired` and custom validation:
+NumericUpDown implements `IValidatable` for built-in validation support.
 
 ```xml
 <extras:NumericUpDown
@@ -124,6 +124,31 @@ The control supports validation through `IsRequired` and custom validation:
     RequiredErrorMessage="Quantity is required"
     ValidateCommand="{Binding ValidateQuantityCommand}" />
 ```
+
+### Checking Validation State
+
+```csharp
+if (!numericUpDown.IsValid)
+{
+    foreach (var error in numericUpDown.ValidationErrors)
+    {
+        Debug.WriteLine(error);
+    }
+}
+
+// Trigger validation manually
+var result = numericUpDown.Validate();
+```
+
+### Validation Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| IsRequired | bool | false | Whether a value is required |
+| RequiredErrorMessage | string | "This field is required." | Error message when required but null |
+| IsValid | bool | (read-only) | Current validation state |
+| ValidationErrors | IReadOnlyList&lt;string&gt; | (read-only) | List of validation error messages |
+| ValidateCommand | ICommand | null | Command executed when validation occurs |
 
 ## Properties
 

--- a/docs/controls/rangeslider.md
+++ b/docs/controls/rangeslider.md
@@ -94,6 +94,46 @@ This ensures the thumbs stay at least 10 apart.
 | UpperValueChangedCommand | Execute when upper value changes |
 | RangeChangedCommand | Execute when either value changes |
 
+## Validation
+
+RangeSlider implements `IValidatable` for built-in validation support.
+
+```xml
+<extras:RangeSlider
+    Minimum="0"
+    Maximum="100"
+    LowerValue="{Binding MinPrice}"
+    UpperValue="{Binding MaxPrice}"
+    IsRequired="True"
+    RequiredErrorMessage="Please select a valid price range"
+    ValidateCommand="{Binding OnValidationCommand}" />
+```
+
+### Checking Validation State
+
+```csharp
+if (!rangeSlider.IsValid)
+{
+    foreach (var error in rangeSlider.ValidationErrors)
+    {
+        Debug.WriteLine(error);
+    }
+}
+
+// Trigger validation manually
+var result = rangeSlider.Validate();
+```
+
+### Validation Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| IsRequired | bool | false | Whether a valid range is required |
+| RequiredErrorMessage | string | "This field is required." | Error message when validation fails |
+| IsValid | bool | (read-only) | Current validation state |
+| ValidationErrors | IReadOnlyList&lt;string&gt; | (read-only) | List of validation error messages |
+| ValidateCommand | ICommand | null | Command executed when validation occurs |
+
 ## Properties
 
 | Property | Type | Description |

--- a/docs/controls/rating.md
+++ b/docs/controls/rating.md
@@ -162,7 +162,35 @@ By default, tapping the current rating value clears it to 0. Disable this behavi
 | Circle | Circle icon (●/○) |
 | Thumb | Thumbs up icon (👍) |
 
-## Validation Properties
+## Validation
+
+Rating implements `IValidatable` for built-in validation support.
+
+```xml
+<extras:Rating
+    Value="{Binding UserRating}"
+    IsRequired="True"
+    RequiredErrorMessage="Please provide a rating"
+    MinimumValue="1"
+    ValidateCommand="{Binding OnValidationCommand}" />
+```
+
+### Checking Validation State
+
+```csharp
+if (!rating.IsValid)
+{
+    foreach (var error in rating.ValidationErrors)
+    {
+        Debug.WriteLine(error);
+    }
+}
+
+// Trigger validation manually
+var result = rating.Validate();
+```
+
+### Validation Properties
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
@@ -170,6 +198,6 @@ By default, tapping the current rating value clears it to 0. Disable this behavi
 | RequiredErrorMessage | string | "A rating is required." | Error message when required but not provided |
 | MinimumValue | double? | null | Minimum required value for validation |
 | MinimumValueErrorMessage | string | "Rating must be at least {0}." | Error message when below minimum |
-| IsValid | bool | true | Whether current value passes validation |
-| ValidationErrors | IReadOnlyList\<string\> | - | List of current validation errors |
+| IsValid | bool | (read-only) | Whether current value passes validation |
+| ValidationErrors | IReadOnlyList&lt;string&gt; | (read-only) | List of current validation errors |
 | ValidateCommand | ICommand | null | Command executed when validation is triggered |

--- a/docs/controls/tokenentry.md
+++ b/docs/controls/tokenentry.md
@@ -103,6 +103,43 @@ public ICommand ValidateTagCommand => new Command<TokenValidationEventArgs>(e =>
 | TokenRemovedCommand | Execute when token removed |
 | ValidateTokenCommand | Validate before adding |
 
+## Validation
+
+TokenEntry implements `IValidatable` for built-in validation support. This is separate from token-level validation (ValidateTokenCommand).
+
+```xml
+<extras:TokenEntry
+    Tokens="{Binding Tags}"
+    IsRequired="True"
+    RequiredErrorMessage="Please add at least one tag"
+    ValidateCommand="{Binding OnValidationCommand}" />
+```
+
+### Checking Validation State
+
+```csharp
+if (!tokenEntry.IsValid)
+{
+    foreach (var error in tokenEntry.ValidationErrors)
+    {
+        Debug.WriteLine(error);
+    }
+}
+
+// Trigger validation manually
+var result = tokenEntry.Validate();
+```
+
+### Validation Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| IsRequired | bool | false | Whether at least one token is required |
+| RequiredErrorMessage | string | "This field is required." | Error message when required but no tokens |
+| IsValid | bool | (read-only) | Current validation state |
+| ValidationErrors | IReadOnlyList&lt;string&gt; | (read-only) | List of validation error messages |
+| ValidateCommand | ICommand | null | Command executed when validation occurs |
+
 ## Properties
 
 | Property | Type | Description |


### PR DESCRIPTION
## Summary

Fixes #121

- Fix IValidatable interface definition in interfaces.md (remove `IsRequired` which is not part of the interface)
- Add validation section to ComboBox, MultiSelectComboBox, RangeSlider, TokenEntry docs
- Enhance NumericUpDown and Rating validation sections
- List all 7 controls implementing IValidatable
- Add code examples for checking validation state

## Files Modified

- `docs/api/interfaces.md` - Fixed interface definition, added comprehensive docs
- `docs/controls/combobox.md` - Added validation section
- `docs/controls/multiselectcombobox.md` - Added validation section
- `docs/controls/rangeslider.md` - Added validation section
- `docs/controls/tokenentry.md` - Added validation section
- `docs/controls/numericupdown.md` - Enhanced validation section
- `docs/controls/rating.md` - Enhanced validation section

## Test plan

- [ ] Verify all documented properties match source code
- [ ] Verify code examples are syntactically correct