### PR TITLE
docs: fix keyboard shortcuts documentation for 10 controls

### DIFF
--- a/docs/controls/accordion.md
+++ b/docs/controls/accordion.md
@@ -143,12 +143,14 @@ bool isExpanded = accordion.IsItemExpanded(0);
 
 | Key | Action |
 |-----|--------|
-| ↑ | Focus previous header |
-| ↓ | Focus next header |
-| Enter | Toggle focused section |
-| Space | Toggle focused section |
-| Home | Focus first header |
-| End | Focus last header |
+| ↑ | Select previous item |
+| ↓ | Select next item |
+| Home | Select first item |
+| End | Select last item |
+| Enter | Toggle selected item |
+| Space | Toggle selected item |
+| → | Expand selected item |
+| ← | Collapse selected item |
 
 ## Events
 

--- a/docs/controls/bindingnavigator.md
+++ b/docs/controls/bindingnavigator.md
@@ -97,14 +97,14 @@ int totalCount = navigator.Count;
 
 | Key | Action |
 |-----|--------|
-| Home | First item |
-| End | Last item |
-| ← | Previous item |
-| → | Next item |
-| Ctrl+N | Add new item |
+| Home | Move to first |
+| End | Move to last |
+| ← | Move to previous |
+| → | Move to next |
+| Page Up | Move to previous |
+| Page Down | Move to next |
+| Insert | Add new item |
 | Delete | Delete current item |
-| Ctrl+S | Save |
-| Escape | Cancel |
 
 ## Events
 

--- a/docs/controls/breadcrumb.md
+++ b/docs/controls/breadcrumb.md
@@ -116,9 +116,10 @@ breadcrumb.NavigateTo(2); // Navigate to 3rd item
 |-----|--------|
 | ← | Select previous item |
 | → | Select next item |
+| Home | Select first item |
+| End | Select last item |
 | Enter | Navigate to selected item |
-| Home | Navigate to first item |
-| End | Navigate to last item |
+| Space | Navigate to selected item |
 
 ## Events
 

--- a/docs/controls/calendar.md
+++ b/docs/controls/calendar.md
@@ -144,18 +144,12 @@ calendar.SelectDate(new DateTime(2024, 7, 4));
 
 | Key | Action |
 |-----|--------|
-| ← | Previous day |
-| → | Next day |
-| ↑ | Previous week |
-| ↓ | Next week |
+| ← / → / ↑ / ↓ | Navigate dates |
 | Page Up | Previous month |
 | Page Down | Next month |
-| Home | First day of month |
-| End | Last day of month |
-| Enter | Select focused date |
-| Space | Toggle date selection |
-| Ctrl+↑ | Switch to year view |
-| Ctrl+↓ | Switch to month view |
+| Home | Go to today |
+| Enter | Select date |
+| Space | Select date |
 
 ## Events
 

--- a/docs/controls/multiselectcombobox.md
+++ b/docs/controls/multiselectcombobox.md
@@ -61,12 +61,14 @@ A dropdown control that allows selecting multiple items with checkboxes.
 
 | Key | Action |
 |-----|--------|
-| Alt+↓ | Open dropdown |
+| ↓ | Open dropdown / Move to next item |
+| ↑ | Move to previous item |
+| Enter | Open dropdown |
+| Space | Toggle selection on highlighted item |
 | Escape | Close dropdown |
-| ↑ / ↓ | Navigate items |
-| Space | Toggle checkbox |
-| Enter | Close dropdown |
-| Type text | Filter items |
+| Home | Move to first item |
+| End | Move to last item |
+| Ctrl+A | Select all |
 
 ## Events
 

--- a/docs/controls/propertygrid.md
+++ b/docs/controls/propertygrid.md
@@ -165,12 +165,12 @@ var changes = propertyGrid.GetModifiedProperties();
 
 | Key | Action |
 |-----|--------|
-| ↑ | Previous property |
-| ↓ | Next property |
-| Enter | Edit property value |
-| Tab | Move to next property |
-| Escape | Cancel editing |
-| Ctrl+F | Focus search box |
+| ↑ | Select previous property |
+| ↓ | Select next property |
+| ← | Collapse property |
+| → | Expand property |
+| Home | Select first property |
+| End | Select last property |
 
 ## Events
 

--- a/docs/controls/rangeslider.md
+++ b/docs/controls/rangeslider.md
@@ -70,11 +70,13 @@ This ensures the thumbs stay at least 10 apart.
 
 | Key | Action |
 |-----|--------|
+| ← / ↓ | Decrease active thumb value |
+| → / ↑ | Increase active thumb value |
+| Page Up | Large increase |
+| Page Down | Large decrease |
+| Home | Set to minimum |
+| End | Set to maximum |
 | Tab | Switch between thumbs |
-| ← / → | Move focused thumb |
-| Shift+← / → | Move by larger step |
-| Home | Move to minimum |
-| End | Move to maximum |
 
 ## Events
 

--- a/docs/controls/richtexteditor.md
+++ b/docs/controls/richtexteditor.md
@@ -129,11 +129,12 @@ string text = await editor.GetPlainTextAsync();
 | Ctrl+B | Bold |
 | Ctrl+I | Italic |
 | Ctrl+U | Underline |
-| Ctrl+Z | Undo |
-| Ctrl+Y | Redo |
 | Ctrl+C | Copy |
 | Ctrl+X | Cut |
 | Ctrl+V | Paste |
+| Ctrl+Z | Undo |
+| Ctrl+Y | Redo |
+| Ctrl+Shift+Z | Redo |
 
 ## Events
 

--- a/docs/controls/tokenentry.md
+++ b/docs/controls/tokenentry.md
@@ -78,13 +78,11 @@ public ICommand ValidateTagCommand => new Command<TokenValidationEventArgs>(e =>
 
 | Key | Action |
 |-----|--------|
-| Enter | Add token |
-| Backspace | Remove last token (when input empty) |
-| Delete | Remove selected token |
-| ← / → | Navigate tokens |
-| Escape | Clear input / deselect |
-| Ctrl+A | Select all tokens |
-| ↑ / ↓ | Navigate suggestions |
+| Enter | Create token from current text |
+| Backspace | Delete last token (when input empty) |
+| Delete | Delete selected token |
+| ← | Select previous token |
+| → | Deselect token |
 
 ## Events
 

--- a/docs/controls/wizard.md
+++ b/docs/controls/wizard.md
@@ -145,9 +145,12 @@ WizardStep currentStep = wizard.CurrentStep;
 |-----|--------|
 | ← | Previous step |
 | → | Next step |
+| Page Up | Previous step |
+| Page Down | Next step |
+| Home | First step (non-linear mode) |
+| End | Last step (non-linear mode) |
 | Enter | Next step / Finish |
-| Escape | Cancel |
-| Tab | Focus next element |
+| Escape | Cancel wizard |
 
 ## Events
 


### PR DESCRIPTION
## Summary

Fixes #120

Updated keyboard shortcuts documentation to match actual `GetKeyboardShortcuts()` implementations in source code.

## Controls Updated

| Control | Changes |
|---------|---------|
| Accordion | Added expand/collapse with ←/→ keys |
| BindingNavigator | Fixed to match source (PageUp/Down, Insert) |
| Breadcrumb | Added Space for navigation |
| Calendar | Simplified to match source, fixed Home action |
| MultiSelectComboBox | Fixed Enter behavior, added Home/End/Ctrl+A |
| PropertyGrid | Fixed to match source (removed Enter/Tab/Escape/Ctrl+F) |
| RangeSlider | Fixed arrow keys, added PageUp/PageDown |
| RichTextEditor | Added Ctrl+Shift+Z for redo |
| TokenEntry | Simplified to match source implementation |
| Wizard | Added PageUp/PageDown, Home/End for non-linear mode |

## Test plan

- [ ] Verify documented shortcuts match GetKeyboardShortcuts() in each control