### PR TITLE
fix: use web-standard Arrow key names in KeyboardBehavior

### DIFF
--- a/src/MauiControlsExtras/Behaviors/KeyboardBehavior.cs
+++ b/src/MauiControlsExtras/Behaviors/KeyboardBehavior.cs
@@ -240,10 +240,10 @@ public class KeyboardBehavior : Behavior<View>
             Windows.System.VirtualKey.End => "End",
             Windows.System.VirtualKey.PageUp => "PageUp",
             Windows.System.VirtualKey.PageDown => "PageDown",
-            Windows.System.VirtualKey.Up => "Up",
-            Windows.System.VirtualKey.Down => "Down",
-            Windows.System.VirtualKey.Left => "Left",
-            Windows.System.VirtualKey.Right => "Right",
+            Windows.System.VirtualKey.Up => "ArrowUp",
+            Windows.System.VirtualKey.Down => "ArrowDown",
+            Windows.System.VirtualKey.Left => "ArrowLeft",
+            Windows.System.VirtualKey.Right => "ArrowRight",
             Windows.System.VirtualKey.F1 => "F1",
             Windows.System.VirtualKey.F2 => "F2",
             Windows.System.VirtualKey.F3 => "F3",
@@ -383,10 +383,10 @@ public class KeyboardBehavior : Behavior<View>
     {
         var input = command.Input;
 
-        if (input == UIKit.UIKeyCommand.UpArrow) return "Up";
-        if (input == UIKit.UIKeyCommand.DownArrow) return "Down";
-        if (input == UIKit.UIKeyCommand.LeftArrow) return "Left";
-        if (input == UIKit.UIKeyCommand.RightArrow) return "Right";
+        if (input == UIKit.UIKeyCommand.UpArrow) return "ArrowUp";
+        if (input == UIKit.UIKeyCommand.DownArrow) return "ArrowDown";
+        if (input == UIKit.UIKeyCommand.LeftArrow) return "ArrowLeft";
+        if (input == UIKit.UIKeyCommand.RightArrow) return "ArrowRight";
         if (input == UIKit.UIKeyCommand.Escape) return "Escape";
         if (input == "\r") return "Enter";
         if (input == "\t") return "Tab";

--- a/src/MauiControlsExtras/Controls/RangeSlider.xaml.cs
+++ b/src/MauiControlsExtras/Controls/RangeSlider.xaml.cs
@@ -1383,8 +1383,8 @@ public partial class RangeSlider : StyledControlBase, IValidatable, Base.IKeyboa
 
         return e.Key switch
         {
-            "Left" or "Down" => HandleDecrementKey(step),
-            "Right" or "Up" => HandleIncrementKey(step),
+            "ArrowLeft" or "ArrowDown" => HandleDecrementKey(step),
+            "ArrowRight" or "ArrowUp" => HandleIncrementKey(step),
             "PageDown" => HandleDecrementKey(largeStep),
             "PageUp" => HandleIncrementKey(largeStep),
             "Home" => HandleHomeKey(),


### PR DESCRIPTION
## Summary

- Fix arrow key shortcuts by using web-standard key names (`ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`) instead of short names (`Up`, `Down`, `Left`, `Right`)
- Update both Windows and Mac key conversion methods in `KeyboardBehavior`
- Update `RangeSlider` to use the new key names

## Affected Controls

This fix enables arrow key navigation for:
- Accordion (↑↓ to navigate, ←→ to collapse/expand)
- Calendar (arrow keys to navigate dates)
- Breadcrumb (←→ to navigate items)
- PropertyGrid (↑↓ to navigate, ←→ to collapse/expand)
- Wizard (←→ for prev/next step)
- BindingNavigator (←→ for prev/next)

Fixes #132