### PR TITLE
feat(DataGridView): add RowSelectedCommand and RowDeselectedCommand

### DIFF
--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridEventArgs.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridEventArgs.cs
@@ -601,3 +601,28 @@ public class DataGridContextMenuAction
     }
 }
 
+/// <summary>
+/// Event arguments for row selection events.
+/// </summary>
+public class DataGridRowSelectionEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the data item of the row.
+    /// </summary>
+    public object Item { get; }
+
+    /// <summary>
+    /// Gets the index of the row.
+    /// </summary>
+    public int RowIndex { get; }
+
+    /// <summary>
+    /// Initializes a new instance of DataGridRowSelectionEventArgs.
+    /// </summary>
+    public DataGridRowSelectionEventArgs(object item, int rowIndex)
+    {
+        Item = item;
+        RowIndex = rowIndex;
+    }
+}
+


### PR DESCRIPTION
## Summary

Adds granular per-row selection commands for proper MVVM support in DataGridView.

## Changes

- Add `DataGridRowSelectionEventArgs` class with:
  - `Item`: the row data item
  - `RowIndex`: the row index
- Add `RowSelectedCommand` bindable property - fires when a row is selected
- Add `RowDeselectedCommand` bindable property - fires when a row is deselected
- Add `RowSelected` and `RowDeselected` events
- Fire events/commands from all selection operations:
  - `SelectRow` - fires RowSelected for new selection, RowDeselected for cleared items in Single mode
  - `ToggleRowSelection` - fires RowSelected or RowDeselected based on toggle direction
  - `ClearSelection` - fires RowDeselected for all cleared items
  - `SelectAll` - fires RowSelected for newly selected items

## Use Cases

- Track individual row selections for analytics
- Perform per-row operations on selection/deselection
- Different handling for select vs deselect actions

## Test plan

- [ ] Verify `RowSelectedCommand` fires when a row is selected
- [ ] Verify `RowDeselectedCommand` fires when a row is deselected
- [ ] Verify commands work with Single selection mode
- [ ] Verify commands work with Multiple selection mode
- [ ] Verify commands work with Extended selection mode
- [ ] Verify `ClearSelection` fires deselected for all items
- [ ] Verify `SelectAll` fires selected for all items
- [ ] Verify command parameters contain correct item and row index

Closes #111