### PR TITLE
feat(Wizard): add StepValidatingCommand

### DIFF
--- a/src/MauiControlsExtras/Controls/Wizard/WizardEventArgs.cs
+++ b/src/MauiControlsExtras/Controls/Wizard/WizardEventArgs.cs
@@ -151,3 +151,78 @@ public class WizardCancellingEventArgs : EventArgs
         CurrentIndex = currentIndex;
     }
 }
+
+/// <summary>
+/// Navigation direction for wizard step transitions.
+/// </summary>
+public enum WizardNavigationDirection
+{
+    /// <summary>
+    /// Moving forward to a higher step index.
+    /// </summary>
+    Forward,
+
+    /// <summary>
+    /// Moving backward to a lower step index.
+    /// </summary>
+    Backward
+}
+
+/// <summary>
+/// Event arguments for wizard step validation (cancelable with validation errors).
+/// </summary>
+public class WizardStepValidatingEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the current step.
+    /// </summary>
+    public WizardStep? CurrentStep { get; }
+
+    /// <summary>
+    /// Gets the target step.
+    /// </summary>
+    public WizardStep? TargetStep { get; }
+
+    /// <summary>
+    /// Gets the current step index.
+    /// </summary>
+    public int CurrentStepIndex { get; }
+
+    /// <summary>
+    /// Gets the target step index.
+    /// </summary>
+    public int TargetStepIndex { get; }
+
+    /// <summary>
+    /// Gets the navigation direction.
+    /// </summary>
+    public WizardNavigationDirection Direction { get; }
+
+    /// <summary>
+    /// Gets or sets whether the navigation should be cancelled.
+    /// </summary>
+    public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Gets the collection of validation errors to display.
+    /// </summary>
+    public IList<string> ValidationErrors { get; } = new List<string>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WizardStepValidatingEventArgs"/> class.
+    /// </summary>
+    public WizardStepValidatingEventArgs(
+        WizardStep? currentStep,
+        WizardStep? targetStep,
+        int currentStepIndex,
+        int targetStepIndex)
+    {
+        CurrentStep = currentStep;
+        TargetStep = targetStep;
+        CurrentStepIndex = currentStepIndex;
+        TargetStepIndex = targetStepIndex;
+        Direction = targetStepIndex > currentStepIndex
+            ? WizardNavigationDirection.Forward
+            : WizardNavigationDirection.Backward;
+    }
+}


### PR DESCRIPTION
## Summary

Adds cancelable step validation command for MVVM scenarios in Wizard control.

## Changes

- Add `WizardNavigationDirection` enum (`Forward`, `Backward`)
- Add `WizardStepValidatingEventArgs` with:
  - `CurrentStep` / `TargetStep`: the step objects
  - `CurrentStepIndex` / `TargetStepIndex`: the step indices
  - `Direction`: navigation direction (Forward/Backward)
  - `Cancel`: set to true to prevent navigation
  - `ValidationErrors`: collection for displaying validation errors
- Add `StepValidatingCommand` bindable property
- Add `StepValidating` event
- Fire event/command in `GoToStep` before existing `StepChanging` logic

## Use Cases

- Validate form data before proceeding to next step
- Prevent backward navigation after certain point
- Show validation errors without changing step
- Async validation (API calls)

## Example Usage

```csharp
public ICommand StepValidatingCommand => new Command<WizardStepValidatingEventArgs>(args =>
{
    if (args.Direction == WizardNavigationDirection.Forward)
    {
        if (string.IsNullOrEmpty(UserName))
        {
            args.ValidationErrors.Add("Username is required");
            args.Cancel = true;
        }
    }
});
```

## Test plan

- [ ] Verify `StepValidatingCommand` fires before step change
- [ ] Verify setting `Cancel = true` prevents navigation
- [ ] Verify `ValidationErrors` collection is populated
- [ ] Verify works for Next, Previous, and direct step jumps
- [ ] Verify `Direction` is correct for forward/backward navigation

Closes #114