### PR TITLE
feat(Accordion): migrate to HeaderedControlBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Accordion**: Now inherits from `HeaderedControlBase` instead of `StyledControlBase` (#95)
+  - Adds: `HeaderFontAttributes`, `HeaderFontFamily`, `HeaderHeight`, `HeaderBorderColor`, `HeaderBorderThickness`
+  - **Breaking**: Default `HeaderFontSize` changed from 14 to 16
+  - **Breaking**: Default `HeaderPadding` changed from (12,10) to (12,8)
+  - **Breaking**: Headers are now bold by default (`HeaderFontAttributes = Bold`)
+
 ### Added
 
 - **ComboBox**: `IsSearchVisible` property to show/hide the search input in dropdowns (#91)

--- a/docs/controls/accordion.md
+++ b/docs/controls/accordion.md
@@ -84,7 +84,28 @@ An accordion control with expandable/collapsible sections.
 <extras:Accordion
     HeaderBackgroundColor="#F5F5F5"
     HeaderTextColor="#333333"
-    HeaderFontSize="16"
+    HeaderFontSize="18"
+    HeaderFontAttributes="Bold"
+    HeaderFontFamily="OpenSans"
+    HeaderPadding="16,12" />
+```
+
+### Removing Bold Headers
+
+Headers are bold by default. To use regular weight:
+
+```xml
+<extras:Accordion HeaderFontAttributes="None" />
+```
+
+### Legacy Styling
+
+To match pre-migration styling (smaller, non-bold headers):
+
+```xml
+<extras:Accordion
+    HeaderFontSize="14"
+    HeaderFontAttributes="None"
     HeaderPadding="12,10" />
 ```
 
@@ -180,8 +201,13 @@ bool isExpanded = accordion.IsItemExpanded(0);
 | AnimationDuration | uint | 200 | Animation duration (ms) |
 | HeaderBackgroundColor | Color | null | Header background |
 | HeaderTextColor | Color | null | Header text color |
-| HeaderFontSize | double | 14 | Header font size |
-| HeaderPadding | Thickness | 12,10 | Header padding |
+| HeaderFontSize | double | 16 | Header font size |
+| HeaderFontAttributes | FontAttributes | Bold | Header font style (Bold, Italic, None) |
+| HeaderFontFamily | string | null | Header font family |
+| HeaderPadding | Thickness | 12,8 | Header padding |
+| HeaderHeight | double | -1 | Header height (-1 = auto) |
+| HeaderBorderColor | Color | null | Header border color |
+| HeaderBorderThickness | Thickness | 0,0,0,1 | Header border thickness |
 | ContentPadding | Thickness | 12,8 | Content padding |
 | ShowDividers | bool | true | Show section dividers |
 

--- a/src/MauiControlsExtras/Controls/Accordion/Accordion.xaml
+++ b/src/MauiControlsExtras/Controls/Accordion/Accordion.xaml
@@ -1,24 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<base:StyledControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                        xmlns:base="clr-namespace:MauiControlsExtras.Base"
-                        xmlns:local="clr-namespace:MauiControlsExtras.Controls"
-                        x:Class="MauiControlsExtras.Controls.Accordion"
-                        x:Name="thisControl">
-
-    <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
-            Stroke="{Binding EffectiveBorderColor, Source={x:Reference thisControl}}"
-            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1E1E1E}">
-        <Border.StrokeShape>
-            <RoundRectangle CornerRadius="{Binding EffectiveCornerRadius, Source={x:Reference thisControl}}" />
-        </Border.StrokeShape>
-
-        <ScrollView Orientation="Vertical"
-                    VerticalScrollBarVisibility="Default">
-            <VerticalStackLayout x:Name="itemsContainer"
-                                 Spacing="0">
-                <!-- Accordion items are added dynamically -->
-            </VerticalStackLayout>
-        </ScrollView>
-    </Border>
-</base:StyledControlBase>
+<base:HeaderedControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                          xmlns:base="clr-namespace:MauiControlsExtras.Base"
+                          x:Class="MauiControlsExtras.Controls.Accordion">
+    <!-- Visual tree is built in code to avoid conflict with [ContentProperty(nameof(Items))] -->
+</base:HeaderedControlBase>


### PR DESCRIPTION
## Summary

- Migrate Accordion from `StyledControlBase` to `HeaderedControlBase`
- Remove duplicate header property definitions (now inherited from base)
- Add virtual method overrides to trigger RebuildUI on property changes
- Fix pre-existing bug where Accordion wasn't rendering due to ContentProperty conflict

## Breaking Changes

| Change | Old Default | New Default |
|--------|-------------|-------------|
| `HeaderFontSize` | 14 | 16 |
| `HeaderPadding` | (12, 10) | (12, 8) |
| `HeaderFontAttributes` | None | Bold |

## New Properties (from HeaderedControlBase)

- `HeaderFontAttributes` - Bold, Italic, None
- `HeaderFontFamily` - Custom font family
- `HeaderHeight` - Fixed height (-1 = auto)
- `HeaderBorderColor` - Header border color
- `HeaderBorderThickness` - Header border thickness

## Test Plan

- [x] Build passes
- [x] Accordion renders with bold headers
- [x] Expand/collapse functionality works
- [x] Single and Multiple expand modes work

Closes #95