### PR TITLE
feat(Calendar): migrate to HeaderedControlBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Calendar**: Now inherits from `HeaderedControlBase` instead of `StyledControlBase` (#96)
+  - Adds: `HeaderBackgroundColor`, `HeaderTextColor`, `HeaderFontSize`, `HeaderFontAttributes`, `HeaderFontFamily`, `HeaderPadding`
+  - Month/year navigation header can now be styled via properties
 - **Accordion**: Now inherits from `HeaderedControlBase` instead of `StyledControlBase` (#95)
   - Adds: `HeaderFontAttributes`, `HeaderFontFamily`, `HeaderHeight`, `HeaderBorderColor`, `HeaderBorderThickness`
   - **Breaking**: Default `HeaderFontSize` changed from 14 to 16
@@ -62,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Calendar**: Range selection now works correctly - second click completes the range instead of resetting
 - **DataGridView**: Filter icon now distinct from sort arrows (⫶ vs ▲/▼) (#63)
 - **DataGridView**: Feature toggle checkboxes now update UI correctly (#64)
 - **DataGridView**: Selection performance with targeted visual updates (#52, #58)

--- a/docs/controls/calendar.md
+++ b/docs/controls/calendar.md
@@ -92,6 +92,17 @@ public ObservableCollection<DateTime> SelectedDates { get; } = new();
 <extras:Calendar ShowWeekNumbers="True" />
 ```
 
+## Header Styling
+
+```xml
+<extras:Calendar
+    HeaderBackgroundColor="#F0F0F0"
+    HeaderTextColor="#333333"
+    HeaderFontSize="18"
+    HeaderFontAttributes="Bold"
+    HeaderPadding="8,4" />
+```
+
 ## Styling
 
 ```xml
@@ -165,11 +176,18 @@ calendar.SelectDate(new DateTime(2024, 7, 4));
 |---------|-------------|
 | DateSelectedCommand | Execute when date is selected |
 | DisplayDateChangedCommand | Execute when display date changes |
+| ClearSelectionCommand | Clear all selected dates and reset range |
 
 ## Properties
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
+| HeaderBackgroundColor | Color | null | Month/year bar background |
+| HeaderTextColor | Color | null | Month/year text color |
+| HeaderFontSize | double | 16 | Header font size |
+| HeaderFontAttributes | FontAttributes | Bold | Header font style |
+| HeaderFontFamily | string | null | Header font family |
+| HeaderPadding | Thickness | 12,8 | Header padding |
 | SelectedDate | DateTime? | null | Selected date (single mode) |
 | SelectedDates | IList&lt;DateTime&gt; | empty | Selected dates (multiple mode) |
 | RangeStart | DateTime? | null | Range start (range mode) |

--- a/samples/DemoApp/Views/CalendarDemoPage.xaml
+++ b/samples/DemoApp/Views/CalendarDemoPage.xaml
@@ -42,8 +42,14 @@
                                      HorizontalOptions="Start" />
 
                     <HorizontalStackLayout Spacing="20">
-                        <Label Text="{Binding RangeStartDate, StringFormat='From: {0:d}', TargetNullValue='From: -'}" />
-                        <Label Text="{Binding RangeEndDate, StringFormat='To: {0:d}', TargetNullValue='To: -'}" />
+                        <Label Text="{Binding RangeStartDate, StringFormat='From: {0:d}', TargetNullValue='From: -'}"
+                               VerticalOptions="Center" />
+                        <Label Text="{Binding RangeEndDate, StringFormat='To: {0:d}', TargetNullValue='To: -'}"
+                               VerticalOptions="Center" />
+                        <Button Text="Clear Range"
+                                Clicked="OnClearRangeClicked"
+                                Padding="12,6"
+                                FontSize="12" />
                     </HorizontalStackLayout>
                 </VerticalStackLayout>
             </Frame>
@@ -59,7 +65,29 @@
                                      DateSelected="OnMultipleDateSelected"
                                      HorizontalOptions="Start" />
 
-                    <Label x:Name="multipleDatesLabel" Text="0 dates selected" />
+                    <HorizontalStackLayout Spacing="20">
+                        <Label x:Name="multipleDatesLabel" Text="0 dates selected" VerticalOptions="Center" />
+                        <Button Text="Clear Selection"
+                                Clicked="OnClearMultipleClicked"
+                                Padding="12,6"
+                                FontSize="12" />
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </Frame>
+
+            <!-- Header Styling -->
+            <Frame Style="{StaticResource DemoCardStyle}">
+                <VerticalStackLayout Spacing="15">
+                    <Label Text="Header Styling" Style="{StaticResource SectionTitleStyle}" />
+                    <Label Text="Customize the month/year navigation header appearance." Style="{StaticResource SectionDescriptionStyle}" />
+
+                    <extras:Calendar SelectionMode="Single"
+                                     HeaderBackgroundColor="#6200EE"
+                                     HeaderTextColor="White"
+                                     HeaderFontSize="18"
+                                     HeaderFontAttributes="Bold"
+                                     HeaderPadding="12,8"
+                                     HorizontalOptions="Start" />
                 </VerticalStackLayout>
             </Frame>
 

--- a/samples/DemoApp/Views/CalendarDemoPage.xaml.cs
+++ b/samples/DemoApp/Views/CalendarDemoPage.xaml.cs
@@ -32,11 +32,24 @@ public partial class CalendarDemoPage : ContentPage
         }
     }
 
+    private void OnClearRangeClicked(object? sender, EventArgs e)
+    {
+        rangeCalendar.ClearSelection();
+        _viewModel.RangeStartDate = null;
+        _viewModel.RangeEndDate = null;
+    }
+
     private void OnMultipleDateSelected(object? sender, CalendarDateSelectedEventArgs e)
     {
         if (sender is Calendar calendar)
         {
             multipleDatesLabel.Text = $"{calendar.SelectedDates.Count} dates selected";
         }
+    }
+
+    private void OnClearMultipleClicked(object? sender, EventArgs e)
+    {
+        multipleCalendar.ClearSelection();
+        multipleDatesLabel.Text = "0 dates selected";
     }
 }

--- a/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml
+++ b/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<base:StyledControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                        xmlns:base="clr-namespace:MauiControlsExtras.Base"
-                        xmlns:local="clr-namespace:MauiControlsExtras.Controls"
-                        x:Class="MauiControlsExtras.Controls.Calendar"
-                        x:Name="thisControl">
+<base:HeaderedControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                          xmlns:base="clr-namespace:MauiControlsExtras.Base"
+                          xmlns:local="clr-namespace:MauiControlsExtras.Controls"
+                          x:Class="MauiControlsExtras.Controls.Calendar"
+                          x:Name="thisControl">
 
     <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
             Stroke="{Binding EffectiveBorderColor, Source={x:Reference thisControl}}"
@@ -19,7 +19,8 @@
             <!-- Navigation Header -->
             <Grid Grid.Row="0"
                   ColumnDefinitions="Auto,*,Auto"
-                  Padding="4">
+                  BackgroundColor="{Binding EffectiveHeaderBackgroundColor, Source={x:Reference thisControl}}"
+                  Padding="{Binding HeaderPadding, Source={x:Reference thisControl}}">
 
                 <Button x:Name="previousButton"
                         Grid.Column="0"
@@ -35,9 +36,10 @@
                        Grid.Column="1"
                        HorizontalOptions="Center"
                        VerticalOptions="Center"
-                       FontSize="16"
-                       FontAttributes="Bold"
-                       TextColor="{Binding EffectiveForegroundColor, Source={x:Reference thisControl}}">
+                       FontSize="{Binding HeaderFontSize, Source={x:Reference thisControl}}"
+                       FontAttributes="{Binding HeaderFontAttributes, Source={x:Reference thisControl}}"
+                       FontFamily="{Binding EffectiveHeaderFontFamily, Source={x:Reference thisControl}}"
+                       TextColor="{Binding EffectiveHeaderTextColor, Source={x:Reference thisControl}}">
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Tapped="OnHeaderTapped" />
                     </Label.GestureRecognizers>
@@ -68,4 +70,4 @@
             </Grid>
         </Grid>
     </Border>
-</base:StyledControlBase>
+</base:HeaderedControlBase>


### PR DESCRIPTION
## Summary

- Migrate Calendar from `StyledControlBase` to `HeaderedControlBase` (#96)
- Add header styling properties for month/year navigation bar customization
- Fix range selection bug where second click reset instead of completing range
- Add demo examples for header styling and clear selection buttons

## Changes

| File | Description |
|------|-------------|
| `Calendar.xaml` | Change root element, bind header to new properties |
| `Calendar.xaml.cs` | Update inheritance, add overrides, fix range selection bug |
| `CalendarDemoPage.xaml` | Add header styling demo, clear buttons |
| `CalendarDemoPage.xaml.cs` | Add clear button handlers |
| `docs/controls/calendar.md` | Document new header properties |
| `CHANGELOG.md` | Document changes |

## New Properties

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| HeaderBackgroundColor | Color | null | Month/year bar background |
| HeaderTextColor | Color | null | Month/year text color |
| HeaderFontSize | double | 16 | Header font size |
| HeaderFontAttributes | FontAttributes | Bold | Header font style |
| HeaderFontFamily | string | null | Header font family |
| HeaderPadding | Thickness | 12,8 | Header padding |

## Bug Fix

Fixed range selection - the `OnSelectedDateChanged` handler was clearing `_selectedDates` when `SelectedDate` was set, wiping out the range. Added `_isInternalSelectionUpdate` flag to prevent this.

## Test plan

- [x] Build succeeds with no errors
- [ ] Calendar renders with default header styling (16pt bold)
- [ ] HeaderBackgroundColor changes month/year bar background
- [ ] HeaderTextColor changes month/year text
- [ ] Range selection: first click sets start, second click completes range
- [ ] Clear buttons work for Range and Multiple selection demos