### PR TITLE
feat(TokenEntry): add clipboard support (IClipboardSupport & IContextMenuSupport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TokenEntry**: Clipboard support with `IClipboardSupport` and `IContextMenuSupport` interface implementations (#109)
+  - Copy/Cut/Paste operations for selected tokens
+  - Keyboard shortcuts (Ctrl+C/X/V on Windows, ⌘C/X/V on Mac)
+  - Right-click context menu on desktop, long-press on mobile
+  - Visual token selection with distinct styling (bold text, accent border)
+  - `PasteDelimiters` property for configurable clipboard text splitting
+  - `Copying`, `Cutting`, `Pasting`, `Pasted` events with cancellation support
+  - `CopyCommand`, `CutCommand`, `PasteCommand` for MVVM
+  - Paste validates tokens against MaxTokens, AllowDuplicates, MaxTokenLength, and ValidationFunc
 - **TreeView**: Context menu support with `IContextMenuSupport` interface implementation
   - `ShowDefaultContextMenu` property to enable built-in menu items (Expand, Collapse, Expand All, Collapse All)
   - `ContextMenuItems` collection for custom menu items

--- a/src/MauiControlsExtras/Controls/TokenEntryEventArgs.cs
+++ b/src/MauiControlsExtras/Controls/TokenEntryEventArgs.cs
@@ -1,0 +1,95 @@
+namespace MauiControlsExtras.Controls;
+
+/// <summary>
+/// Specifies the type of clipboard operation.
+/// </summary>
+public enum TokenClipboardOperation
+{
+    /// <summary>
+    /// Copy operation - token text is copied to clipboard.
+    /// </summary>
+    Copy,
+
+    /// <summary>
+    /// Cut operation - token text is copied to clipboard and removed from the control.
+    /// </summary>
+    Cut,
+
+    /// <summary>
+    /// Paste operation - tokens are added from clipboard text.
+    /// </summary>
+    Paste
+}
+
+/// <summary>
+/// Provides data for clipboard-related events in TokenEntry.
+/// </summary>
+public class TokenClipboardEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the type of clipboard operation.
+    /// </summary>
+    public TokenClipboardOperation Operation { get; }
+
+    /// <summary>
+    /// Gets the tokens involved in the operation.
+    /// For Copy/Cut: the token being copied.
+    /// For Paste: the tokens that will be/were added.
+    /// </summary>
+    public IReadOnlyList<string> Tokens { get; }
+
+    /// <summary>
+    /// Gets the raw clipboard text content.
+    /// For Copy/Cut: the text being copied.
+    /// For Paste: the text from clipboard before splitting.
+    /// </summary>
+    public string Content { get; }
+
+    /// <summary>
+    /// Gets or sets whether to cancel the operation.
+    /// Only applicable for events raised before the operation (Copying, Cutting, Pasting).
+    /// </summary>
+    public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Gets the list of tokens that were skipped during paste operation.
+    /// Only populated for Pasted event.
+    /// </summary>
+    public IReadOnlyList<string> SkippedTokens { get; internal set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets the reasons why tokens were skipped during paste operation.
+    /// Keys are skipped tokens, values are skip reasons.
+    /// Only populated for Pasted event.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> SkipReasons { get; internal set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets the number of tokens successfully added during paste operation.
+    /// Only populated for Pasted event.
+    /// </summary>
+    public int SuccessCount { get; internal set; }
+
+    /// <summary>
+    /// Initializes a new instance of TokenClipboardEventArgs.
+    /// </summary>
+    /// <param name="operation">The type of clipboard operation.</param>
+    /// <param name="tokens">The tokens involved in the operation.</param>
+    /// <param name="content">The raw clipboard text content.</param>
+    public TokenClipboardEventArgs(TokenClipboardOperation operation, IReadOnlyList<string> tokens, string content)
+    {
+        Operation = operation;
+        Tokens = tokens;
+        Content = content;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of TokenClipboardEventArgs for a single token.
+    /// </summary>
+    /// <param name="operation">The type of clipboard operation.</param>
+    /// <param name="token">The token involved in the operation.</param>
+    public TokenClipboardEventArgs(TokenClipboardOperation operation, string token)
+        : this(operation, new[] { token }, token)
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Implements clipboard support for TokenEntry control (#109):

- **IClipboardSupport interface**: Copy, Cut, Paste operations for selected tokens
- **IContextMenuSupport interface**: Right-click (desktop) and long-press (mobile) context menus
- **Keyboard shortcuts**: Ctrl+C/X/V on Windows, ⌘C/X/V on Mac
- **Visual selection**: Selected tokens show bold text and accent border
- **Paste validation**: Respects MaxTokens, AllowDuplicates, MaxTokenLength, ValidationFunc
- **Events**: Copying, Cutting, Pasting, Pasted (with cancellation support)
- **Commands**: CopyCommand, CutCommand, PasteCommand for MVVM
- **Properties**: PasteDelimiters, ShowDefaultContextMenu, CanCopy/Cut/Paste

## Files Changed

| File | Changes |
|------|---------|
| `TokenEntry.xaml.cs` | IClipboardSupport + IContextMenuSupport implementation |
| `TokenEntryEventArgs.cs` | New file for clipboard event args |
| `docs/controls/tokenentry.md` | User documentation |
| `docs/api/tokenentry.md` | API reference |
| `CHANGELOG.md` | Added entry for this feature |

## Test Plan

- [x] Build succeeds with no warnings
- [x] Existing tests pass
- [x] Manual testing: copy, cut, paste operations
- [x] Manual testing: context menu on desktop
- [x] App shutdown no longer throws ObjectDisposedException

Closes #109