### PR TITLE
Fix #158: notify Effective properties on theme change in derived base classes

### DIFF
--- a/src/MauiControlsExtras/Base/HeaderedControlBase.cs
+++ b/src/MauiControlsExtras/Base/HeaderedControlBase.cs
@@ -215,6 +215,20 @@ public abstract class HeaderedControlBase : StyledControlBase
 
     #endregion
 
+    #region Theme Change
+
+    /// <inheritdoc />
+    public override void OnThemeChanged(AppTheme theme)
+    {
+        base.OnThemeChanged(theme);
+        OnPropertyChanged(nameof(EffectiveHeaderBackgroundColor));
+        OnPropertyChanged(nameof(EffectiveHeaderTextColor));
+        OnPropertyChanged(nameof(EffectiveHeaderFontFamily));
+        OnPropertyChanged(nameof(EffectiveHeaderBorderColor));
+    }
+
+    #endregion
+
     #region Property Changed Handlers
 
     private static void OnHeaderBackgroundColorChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/MauiControlsExtras/Base/ListStyledControlBase.cs
+++ b/src/MauiControlsExtras/Base/ListStyledControlBase.cs
@@ -196,6 +196,20 @@ public abstract class ListStyledControlBase : StyledControlBase
 
     #endregion
 
+    #region Theme Change
+
+    /// <inheritdoc />
+    public override void OnThemeChanged(AppTheme theme)
+    {
+        base.OnThemeChanged(theme);
+        OnPropertyChanged(nameof(EffectiveSelectedItemBackgroundColor));
+        OnPropertyChanged(nameof(EffectiveSelectedItemTextColor));
+        OnPropertyChanged(nameof(EffectiveHoverColor));
+        OnPropertyChanged(nameof(EffectiveSeparatorColor));
+    }
+
+    #endregion
+
     #region Property Changed Handlers
 
     private static void OnAlternatingRowColorChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/MauiControlsExtras/Base/NavigationControlBase.cs
+++ b/src/MauiControlsExtras/Base/NavigationControlBase.cs
@@ -202,6 +202,22 @@ public abstract class NavigationControlBase : StyledControlBase
 
     #endregion
 
+    #region Theme Change
+
+    /// <inheritdoc />
+    public override void OnThemeChanged(AppTheme theme)
+    {
+        base.OnThemeChanged(theme);
+        OnPropertyChanged(nameof(EffectiveActiveColor));
+        OnPropertyChanged(nameof(EffectiveInactiveColor));
+        OnPropertyChanged(nameof(EffectiveVisitedColor));
+        OnPropertyChanged(nameof(EffectiveDisabledNavigationColor));
+        OnPropertyChanged(nameof(EffectiveActiveBackgroundColor));
+        OnPropertyChanged(nameof(EffectiveNavigationIndicatorColor));
+    }
+
+    #endregion
+
     #region Property Changed Handlers
 
     private static void OnActiveColorChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/MauiControlsExtras/Base/TextStyledControlBase.cs
+++ b/src/MauiControlsExtras/Base/TextStyledControlBase.cs
@@ -192,6 +192,20 @@ public abstract class TextStyledControlBase : StyledControlBase
 
     #endregion
 
+    #region Theme Change
+
+    /// <inheritdoc />
+    public override void OnThemeChanged(AppTheme theme)
+    {
+        base.OnThemeChanged(theme);
+        OnPropertyChanged(nameof(EffectiveFontFamily));
+        OnPropertyChanged(nameof(EffectiveFontSize));
+        OnPropertyChanged(nameof(EffectiveTextColor));
+        OnPropertyChanged(nameof(EffectivePlaceholderColor));
+    }
+
+    #endregion
+
     #region Property Changed Handlers
 
     private static void OnFontFamilyChanged(BindableObject bindable, object oldValue, object newValue)


### PR DESCRIPTION
## Summary

Derived base classes (`TextStyledControlBase`, `HeaderedControlBase`, `NavigationControlBase`, `ListStyledControlBase`) did not override `OnThemeChanged` to notify their own Effective properties. This caused XAML bindings to go stale when the global theme changed.

## What changed

- **TextStyledControlBase**: override `OnThemeChanged` → notifies `EffectiveFontFamily`, `EffectiveFontSize`, `EffectiveTextColor`, `EffectivePlaceholderColor`
- **HeaderedControlBase**: override `OnThemeChanged` → notifies `EffectiveHeaderBackgroundColor`, `EffectiveHeaderTextColor`, `EffectiveHeaderFontFamily`, `EffectiveHeaderBorderColor`
- **NavigationControlBase**: override `OnThemeChanged` → notifies `EffectiveActiveColor`, `EffectiveInactiveColor`, `EffectiveVisitedColor`, `EffectiveDisabledNavigationColor`, `EffectiveActiveBackgroundColor`, `EffectiveNavigationIndicatorColor`
- **ListStyledControlBase**: override `OnThemeChanged` → notifies `EffectiveSelectedItemBackgroundColor`, `EffectiveSelectedItemTextColor`, `EffectiveHoverColor`, `EffectiveSeparatorColor`

## Validation performed

- `dotnet build` — 0 warnings, 0 errors
- `dotnet test` — 14/14 passed
- DemoApp build (net10.0-windows) — success

## Manual verification checklist

- [ ] Change theme at runtime → verify derived Effective properties update in UI
- [ ] Accordion/Calendar header colors update on theme change
- [ ] Wizard navigation colors update on theme change
- [ ] ComboBox/TokenEntry text colors update on theme change
- [ ] TreeView/DataGridView list colors update on theme change

Closes #158