### PR TITLE
fix(Keyboard): use Arrow* key names consistently across all controls (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Keyboard**: Arrow key names now use `"Arrow*"` convention consistently across all controls (#174)
+  - Fixes broken arrow key navigation in TreeView, DataGrid, ComboBox, MultiSelectComboBox, NumericUpDown, Rating, and TokenEntry
+  - Aligns `GetMacKeyCommands` in `KeyboardBehavior` with the same naming convention
+
 ### Changed
 
 - **Wizard**: Now inherits from `NavigationControlBase` instead of `HeaderedControlBase` (#103)

--- a/src/MauiControlsExtras/Behaviors/KeyboardBehavior.cs
+++ b/src/MauiControlsExtras/Behaviors/KeyboardBehavior.cs
@@ -329,10 +329,10 @@ public class KeyboardBehavior : Behavior<View>
         var commands = new List<UIKit.UIKeyCommand>();
 
         // Arrow keys
-        commands.Add(CreateMacKeyCommand(UIKit.UIKeyCommand.UpArrow, 0, "Up"));
-        commands.Add(CreateMacKeyCommand(UIKit.UIKeyCommand.DownArrow, 0, "Down"));
-        commands.Add(CreateMacKeyCommand(UIKit.UIKeyCommand.LeftArrow, 0, "Left"));
-        commands.Add(CreateMacKeyCommand(UIKit.UIKeyCommand.RightArrow, 0, "Right"));
+        commands.Add(CreateMacKeyCommand(UIKit.UIKeyCommand.UpArrow, 0, "ArrowUp"));
+        commands.Add(CreateMacKeyCommand(UIKit.UIKeyCommand.DownArrow, 0, "ArrowDown"));
+        commands.Add(CreateMacKeyCommand(UIKit.UIKeyCommand.LeftArrow, 0, "ArrowLeft"));
+        commands.Add(CreateMacKeyCommand(UIKit.UIKeyCommand.RightArrow, 0, "ArrowRight"));
 
         // Common shortcuts with Command key
         commands.Add(CreateMacKeyCommand("a", UIKit.UIKeyModifierFlags.Command, "A"));

--- a/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
@@ -1676,8 +1676,8 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
 
         return e.Key switch
         {
-            "Down" => HandleDownKey(),
-            "Up" => HandleUpKey(),
+            "ArrowDown" => HandleDownKey(),
+            "ArrowUp" => HandleUpKey(),
             "Enter" or "Space" => HandleEnterKey(),
             "Escape" => HandleEscapeKey(),
             "Home" => HandleHomeKey(),
@@ -1693,10 +1693,10 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
         {
             _keyboardShortcuts.AddRange(new[]
             {
-                new Base.KeyboardShortcut { Key = "Alt+Down", Description = "Open dropdown", Category = "Action" },
-                new Base.KeyboardShortcut { Key = "Alt+Up", Description = "Close dropdown", Category = "Action" },
-                new Base.KeyboardShortcut { Key = "Down", Description = "Open dropdown / Move to next item", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Up", Description = "Move to previous item", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "Alt+ArrowDown", Description = "Open dropdown", Category = "Action" },
+                new Base.KeyboardShortcut { Key = "Alt+ArrowUp", Description = "Close dropdown", Category = "Action" },
+                new Base.KeyboardShortcut { Key = "ArrowDown", Description = "Open dropdown / Move to next item", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowUp", Description = "Move to previous item", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "Enter", Description = "Select highlighted item / Open dropdown", Category = "Action" },
                 new Base.KeyboardShortcut { Key = "Space", Description = "Open dropdown", Category = "Action" },
                 new Base.KeyboardShortcut { Key = "Escape", Description = "Close dropdown", Category = "Action" },

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -5580,10 +5580,10 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         // Handle navigation and action keys
         return e.Key switch
         {
-            "Up" => HandleUpKey(e),
-            "Down" => HandleDownKey(e),
-            "Left" => HandleLeftKey(e),
-            "Right" => HandleRightKey(e),
+            "ArrowUp" => HandleUpKey(e),
+            "ArrowDown" => HandleDownKey(e),
+            "ArrowLeft" => HandleLeftKey(e),
+            "ArrowRight" => HandleRightKey(e),
             "Home" => HandleHomeKey(e),
             "End" => HandleEndKey(e),
             "PageUp" => HandlePageUpKey(e),
@@ -5610,10 +5610,10 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         {
             _keyboardShortcuts.AddRange(new[]
             {
-                new Base.KeyboardShortcut { Key = "Up", Description = "Move to previous row", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Down", Description = "Move to next row", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Left", Description = "Move to previous column", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Right", Description = "Move to next column", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowUp", Description = "Move to previous row", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowDown", Description = "Move to next row", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowLeft", Description = "Move to previous column", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowRight", Description = "Move to next column", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "Home", Description = "Move to first column", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "End", Description = "Move to last column", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "Home", Modifiers = "Ctrl", Description = "Move to first cell", Category = "Navigation" },

--- a/src/MauiControlsExtras/Controls/MultiSelectComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/MultiSelectComboBox.xaml.cs
@@ -1403,8 +1403,8 @@ public partial class MultiSelectComboBox : TextStyledControlBase, IValidatable, 
 
         return e.Key switch
         {
-            "Down" => HandleDownKey(),
-            "Up" => HandleUpKey(),
+            "ArrowDown" => HandleDownKey(),
+            "ArrowUp" => HandleUpKey(),
             "Enter" => HandleEnterKey(),
             "Space" => HandleSpaceKey(),
             "Escape" => HandleEscapeKey(),
@@ -1422,8 +1422,8 @@ public partial class MultiSelectComboBox : TextStyledControlBase, IValidatable, 
         {
             _keyboardShortcuts.AddRange(new[]
             {
-                new Base.KeyboardShortcut { Key = "Down", Description = "Open dropdown / Move to next item", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Up", Description = "Move to previous item", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowDown", Description = "Open dropdown / Move to next item", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowUp", Description = "Move to previous item", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "Enter", Description = "Open dropdown", Category = "Action" },
                 new Base.KeyboardShortcut { Key = "Space", Description = "Toggle selection on highlighted item", Category = "Action" },
                 new Base.KeyboardShortcut { Key = "Escape", Description = "Close dropdown", Category = "Action" },

--- a/src/MauiControlsExtras/Controls/NumericUpDown.xaml.cs
+++ b/src/MauiControlsExtras/Controls/NumericUpDown.xaml.cs
@@ -1001,8 +1001,8 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
 
         return e.Key switch
         {
-            "Up" => HandleIncrementKey(),
-            "Down" => HandleDecrementKey(),
+            "ArrowUp" => HandleIncrementKey(),
+            "ArrowDown" => HandleDecrementKey(),
             "PageUp" => HandleLargeIncrementKey(),
             "PageDown" => HandleLargeDecrementKey(),
             "Home" => HandleHomeKey(),
@@ -1018,8 +1018,8 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
         {
             _keyboardShortcuts.AddRange(new[]
             {
-                new Base.KeyboardShortcut { Key = "Up", Description = "Increment value by step", Category = "Value" },
-                new Base.KeyboardShortcut { Key = "Down", Description = "Decrement value by step", Category = "Value" },
+                new Base.KeyboardShortcut { Key = "ArrowUp", Description = "Increment value by step", Category = "Value" },
+                new Base.KeyboardShortcut { Key = "ArrowDown", Description = "Decrement value by step", Category = "Value" },
                 new Base.KeyboardShortcut { Key = "PageUp", Description = "Increment by large step (10x)", Category = "Value" },
                 new Base.KeyboardShortcut { Key = "PageDown", Description = "Decrement by large step (10x)", Category = "Value" },
                 new Base.KeyboardShortcut { Key = "Home", Description = "Set to minimum value", Category = "Value" },

--- a/src/MauiControlsExtras/Controls/Rating.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Rating.xaml.cs
@@ -946,8 +946,8 @@ public partial class Rating : StyledControlBase, IValidatable, Base.IKeyboardNav
 
         return e.Key switch
         {
-            "Left" or "Down" => HandleDecrement(step),
-            "Right" or "Up" => HandleIncrement(step),
+            "ArrowLeft" or "ArrowDown" => HandleDecrement(step),
+            "ArrowRight" or "ArrowUp" => HandleIncrement(step),
             "Home" or "Delete" => HandleClear(),
             "End" => HandleSetMax(),
             "1" => HandleSetValue(1),
@@ -966,8 +966,8 @@ public partial class Rating : StyledControlBase, IValidatable, Base.IKeyboardNav
         {
             _keyboardShortcuts.AddRange(new[]
             {
-                new Base.KeyboardShortcut { Key = "Left/Down", Description = "Decrease rating", Category = "Value" },
-                new Base.KeyboardShortcut { Key = "Right/Up", Description = "Increase rating", Category = "Value" },
+                new Base.KeyboardShortcut { Key = "ArrowLeft/ArrowDown", Description = "Decrease rating", Category = "Value" },
+                new Base.KeyboardShortcut { Key = "ArrowRight/ArrowUp", Description = "Increase rating", Category = "Value" },
                 new Base.KeyboardShortcut { Key = "Home/Delete", Description = "Clear rating", Category = "Value" },
                 new Base.KeyboardShortcut { Key = "End", Description = "Set to maximum", Category = "Value" },
                 new Base.KeyboardShortcut { Key = "1-5", Description = "Set specific rating", Category = "Value" },

--- a/src/MauiControlsExtras/Controls/TokenEntry.xaml.cs
+++ b/src/MauiControlsExtras/Controls/TokenEntry.xaml.cs
@@ -1141,13 +1141,13 @@ public partial class TokenEntry : TextStyledControlBase, IValidatable, Base.IKey
         }
 
         // Handle left arrow to select tokens
-        if (e.Key == "Left" && string.IsNullOrEmpty(Text))
+        if (e.Key == "ArrowLeft" && string.IsNullOrEmpty(Text))
         {
             return HandleLeftKey();
         }
 
         // Handle right arrow to deselect tokens
-        if (e.Key == "Right" && _selectedTokenIndex >= 0)
+        if (e.Key == "ArrowRight" && _selectedTokenIndex >= 0)
         {
             return HandleRightKey();
         }
@@ -1187,8 +1187,8 @@ public partial class TokenEntry : TextStyledControlBase, IValidatable, Base.IKey
                 new Base.KeyboardShortcut { Key = "Enter", Description = "Create token from current text", Category = "Action" },
                 new Base.KeyboardShortcut { Key = "Backspace", Description = "Delete last token (when input empty)", Category = "Action" },
                 new Base.KeyboardShortcut { Key = "Delete", Description = "Delete selected token", Category = "Action" },
-                new Base.KeyboardShortcut { Key = "Left", Description = "Select previous token", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Right", Description = "Deselect token", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowLeft", Description = "Select previous token", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowRight", Description = "Deselect token", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "Ctrl+C", Description = "Copy selected token", Category = "Clipboard" },
                 new Base.KeyboardShortcut { Key = "Ctrl+X", Description = "Cut selected token", Category = "Clipboard" },
                 new Base.KeyboardShortcut { Key = "Ctrl+V", Description = "Paste tokens from clipboard", Category = "Clipboard" },

--- a/src/MauiControlsExtras/Controls/TreeView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/TreeView.xaml.cs
@@ -2282,10 +2282,10 @@ public partial class TreeView : Base.ListStyledControlBase, Base.IKeyboardNaviga
         // Handle navigation and action keys
         return e.Key switch
         {
-            "Up" => HandleUpKey(e),
-            "Down" => HandleDownKey(e),
-            "Left" => HandleLeftKey(e),
-            "Right" => HandleRightKey(e),
+            "ArrowUp" => HandleUpKey(e),
+            "ArrowDown" => HandleDownKey(e),
+            "ArrowLeft" => HandleLeftKey(e),
+            "ArrowRight" => HandleRightKey(e),
             "Home" => HandleHomeKey(e),
             "End" => HandleEndKey(e),
             "PageUp" => HandlePageUpKey(),
@@ -2306,10 +2306,10 @@ public partial class TreeView : Base.ListStyledControlBase, Base.IKeyboardNaviga
         {
             _keyboardShortcuts.AddRange(new[]
             {
-                new Base.KeyboardShortcut { Key = "Up", Description = "Move to previous item", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Down", Description = "Move to next item", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Left", Description = "Collapse node or move to parent", Category = "Navigation" },
-                new Base.KeyboardShortcut { Key = "Right", Description = "Expand node or move to first child", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowUp", Description = "Move to previous item", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowDown", Description = "Move to next item", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowLeft", Description = "Collapse node or move to parent", Category = "Navigation" },
+                new Base.KeyboardShortcut { Key = "ArrowRight", Description = "Expand node or move to first child", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "Home", Description = "Move to first item", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "End", Description = "Move to last item", Category = "Navigation" },
                 new Base.KeyboardShortcut { Key = "PageUp", Description = "Move up one page", Category = "Navigation" },


### PR DESCRIPTION
## Summary

Arrow key names were inconsistent across controls. Some used bare names (`"Up"`, `"Down"`, `"Left"`, `"Right"`) while `KeyboardBehavior` emits `"ArrowUp"`, `"ArrowDown"`, `"ArrowLeft"`, `"ArrowRight"`. This caused arrow key navigation to silently fail on affected controls.

## What changed

- **TreeView**: Updated `HandleKeyPress` and `GetKeyboardShortcuts` to use `"Arrow*"` names
- **DataGridView**: Updated `HandleKeyPress` and `GetKeyboardShortcuts` to use `"Arrow*"` names
- **ComboBox**: Updated `HandleKeyPress` and `GetKeyboardShortcuts` to use `"Arrow*"` names
- **MultiSelectComboBox**: Updated `HandleKeyPress` and `GetKeyboardShortcuts` to use `"Arrow*"` names
- **NumericUpDown**: Updated `HandleKeyPress` and `GetKeyboardShortcuts` to use `"Arrow*"` names
- **Rating**: Updated `HandleKeyPress` and `GetKeyboardShortcuts` to use `"Arrow*"` names
- **TokenEntry**: Updated `HandleKeyPress` and `GetKeyboardShortcuts` to use `"Arrow*"` names
- **KeyboardBehavior**: Updated `GetMacKeyCommands` to emit `"Arrow*"` names (aligning with `ConvertMacKey`)
- **CHANGELOG**: Added entry under `[Unreleased] > Fixed`

## Validation performed

- `dotnet build src/MauiControlsExtras/MauiControlsExtras.csproj` — 0 warnings, 0 errors
- `dotnet build samples/DemoApp/DemoApp.csproj` — 0 warnings, 0 errors
- `dotnet test` — 14 passed, 0 failed

## Manual verification checklist

- [ ] Arrow key navigation works in TreeView on Windows
- [ ] Arrow key navigation works in DataGridView on Windows
- [ ] Arrow key navigation works in ComboBox dropdown on Windows
- [ ] Arrow key navigation works on macOS (Mac Catalyst)

Closes #174