### PR TITLE
docs: add Breadcrumb NavigatingCommand to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Breadcrumb**: `NavigatingCommand` and `NavigatingCommandParameter` bindable properties for MVVM support on the `Navigating` event (#160)
 - **TokenEntry**: Clipboard support with `IClipboardSupport` and `IContextMenuSupport` interface implementations (#109)
   - Copy/Cut/Paste operations for selected tokens
   - Keyboard shortcuts (Ctrl+C/X/V on Windows, ⌘C/X/V on Mac)


### PR DESCRIPTION
## Summary
- Adds the missing changelog entry for `NavigatingCommand` / `NavigatingCommandParameter` added in #179

Relates to #160