### PR TITLE
feat(Focus): add focus border visuals for keyboard navigation

### DIFF
--- a/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml
+++ b/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml
@@ -7,7 +7,7 @@
                         x:Name="thisControl">
 
     <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
-            Stroke="{Binding EffectiveBorderColor, Source={x:Reference thisControl}}"
+            Stroke="{Binding CurrentBorderColor, Source={x:Reference thisControl}}"
             BackgroundColor="{Binding EffectiveBackgroundColor, Source={x:Reference thisControl}}"
             Padding="{Binding Padding, Source={x:Reference thisControl}}">
         <Border.StrokeShape>

--- a/src/MauiControlsExtras/Controls/Rating.xaml
+++ b/src/MauiControlsExtras/Controls/Rating.xaml
@@ -5,10 +5,18 @@
                         x:Class="MauiControlsExtras.Controls.Rating"
                         x:Name="thisControl">
 
-    <HorizontalStackLayout x:Name="iconsContainer"
-                           Spacing="{Binding Spacing, Source={x:Reference thisControl}}"
-                           HorizontalOptions="Start"
-                           VerticalOptions="Center">
-        <!-- Rating icons are added dynamically -->
-    </HorizontalStackLayout>
+    <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
+            Stroke="{Binding CurrentBorderColor, Source={x:Reference thisControl}}"
+            Padding="4">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="{Binding EffectiveCornerRadius, Source={x:Reference thisControl}}" />
+        </Border.StrokeShape>
+
+        <HorizontalStackLayout x:Name="iconsContainer"
+                               Spacing="{Binding Spacing, Source={x:Reference thisControl}}"
+                               HorizontalOptions="Start"
+                               VerticalOptions="Center">
+            <!-- Rating icons are added dynamically -->
+        </HorizontalStackLayout>
+    </Border>
 </base:StyledControlBase>

--- a/src/MauiControlsExtras/Controls/Rating.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Rating.xaml.cs
@@ -397,6 +397,12 @@ public partial class Rating : StyledControlBase, IValidatable, Base.IKeyboardNav
     }
 
     /// <summary>
+    /// Gets the current border color based on focus state.
+    /// </summary>
+    public Color CurrentBorderColor =>
+        IsFocused ? EffectiveFocusBorderColor : EffectiveBorderColor;
+
+    /// <summary>
     /// Gets whether the current value is valid.
     /// </summary>
     public bool IsValid => _isValid;
@@ -467,6 +473,8 @@ public partial class Rating : StyledControlBase, IValidatable, Base.IKeyboardNav
     {
         InitializeComponent();
         BuildIcons();
+        Focused += OnControlFocused;
+        Unfocused += OnControlUnfocused;
     }
 
     #endregion
@@ -677,10 +685,26 @@ public partial class Rating : StyledControlBase, IValidatable, Base.IKeyboardNav
 
     #region Event Handlers
 
+    private void OnControlFocused(object? sender, FocusEventArgs e)
+    {
+        OnPropertyChanged(nameof(CurrentBorderColor));
+        KeyboardFocusGained?.Invoke(this, new Base.KeyboardFocusEventArgs(true));
+        GotFocusCommand?.Execute(this);
+    }
+
+    private void OnControlUnfocused(object? sender, FocusEventArgs e)
+    {
+        OnPropertyChanged(nameof(CurrentBorderColor));
+        KeyboardFocusLost?.Invoke(this, new Base.KeyboardFocusEventArgs(false));
+        LostFocusCommand?.Execute(this);
+    }
+
     private void OnIconTapped(int index, TappedEventArgs e)
     {
         if (IsReadOnly)
             return;
+
+        Focus();
 
         double newValue;
 
@@ -914,9 +938,7 @@ public partial class Rating : StyledControlBase, IValidatable, Base.IKeyboardNav
     public event EventHandler<Base.KeyboardFocusEventArgs>? KeyboardFocusGained;
 
     /// <inheritdoc />
-#pragma warning disable CS0067 // Event is never used (raised by platform-specific handlers)
     public event EventHandler<Base.KeyboardFocusEventArgs>? KeyboardFocusLost;
-#pragma warning restore CS0067
 
     /// <inheritdoc />
     public event EventHandler<Base.KeyEventArgs>? KeyPressed;


### PR DESCRIPTION
## Summary
- Add `CurrentBorderColor` property to **Rating**, **Accordion**, **Breadcrumb**, and **Wizard** that switches between `EffectiveFocusBorderColor` (focused) and `EffectiveBorderColor` (unfocused)
- Subscribe to `Focused`/`Unfocused` events on all four controls to drive the border color change and raise `KeyboardFocusLost` (previously declared but never invoked)
- Rating: wrap icons in a `Border` bound to `CurrentBorderColor`; call `Focus()` on icon tap so tapping a star also shows the focus ring

Closes #169

## Test plan
- [x] `dotnet build` library — 0 warnings, 0 errors
- [x] `dotnet build` demo app — 0 warnings, 0 errors
- [x] `dotnet test` — 14/14 pass
- [ ] Manual: Tab to Rating, verify focus border appears; tap a star, verify focus border appears; Tab away, verify border reverts
- [ ] Manual: Tab to Accordion, verify focus border appears; Tab away, verify border reverts
- [ ] Manual: Tab to Breadcrumb, verify focus border appears; Tab away, verify border reverts
- [ ] Manual: Tab to Wizard, verify focus border appears; Tab away, verify border reverts