### PR TITLE
docs: remove incorrect ComboBox double-click entry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -571,7 +571,6 @@ Controls with actions MUST support right-click context menus:
 #### Double-Click
 - **DataGridView** - Enter edit mode
 - **TreeView** - Expand/collapse or activate
-- **ComboBox** - Open dropdown
 
 ### Focus Management
 


### PR DESCRIPTION
## Summary
- Removes `ComboBox - Open dropdown` from the Double-Click section in ARCHITECTURE.md
- ComboBox uses single click/tap, not double-click — the implementation (`TapGestureRecognizer` with default `NumberOfTapsRequired=1`) and `docs/platform/mouse.md` already document this correctly

Fixes #173