### PR TITLE
Fix #161: add missing CommandParameter properties across 8 controls

### DIFF
--- a/src/MauiControlsExtras/Controls/Accordion/Accordion.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Accordion/Accordion.xaml.cs
@@ -113,11 +113,27 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         typeof(Accordion));
 
     /// <summary>
+    /// Identifies the <see cref="ItemExpandedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ItemExpandedCommandParameterProperty = BindableProperty.Create(
+        nameof(ItemExpandedCommandParameter),
+        typeof(object),
+        typeof(Accordion));
+
+    /// <summary>
     /// Identifies the <see cref="ItemCollapsedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty ItemCollapsedCommandProperty = BindableProperty.Create(
         nameof(ItemCollapsedCommand),
         typeof(ICommand),
+        typeof(Accordion));
+
+    /// <summary>
+    /// Identifies the <see cref="ItemCollapsedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ItemCollapsedCommandParameterProperty = BindableProperty.Create(
+        nameof(ItemCollapsedCommandParameter),
+        typeof(object),
         typeof(Accordion));
 
     /// <summary>
@@ -129,11 +145,27 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         typeof(Accordion));
 
     /// <summary>
+    /// Identifies the <see cref="GotFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(GotFocusCommandParameter),
+        typeof(object),
+        typeof(Accordion));
+
+    /// <summary>
     /// Identifies the <see cref="LostFocusCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty LostFocusCommandProperty = BindableProperty.Create(
         nameof(LostFocusCommand),
         typeof(ICommand),
+        typeof(Accordion));
+
+    /// <summary>
+    /// Identifies the <see cref="LostFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(LostFocusCommandParameter),
+        typeof(object),
         typeof(Accordion));
 
     /// <summary>
@@ -145,11 +177,27 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         typeof(Accordion));
 
     /// <summary>
+    /// Identifies the <see cref="KeyPressCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandParameterProperty = BindableProperty.Create(
+        nameof(KeyPressCommandParameter),
+        typeof(object),
+        typeof(Accordion));
+
+    /// <summary>
     /// Identifies the <see cref="SelectAllCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectAllCommandProperty = BindableProperty.Create(
         nameof(SelectAllCommand),
         typeof(ICommand),
+        typeof(Accordion));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectAllCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectAllCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectAllCommandParameter),
+        typeof(object),
         typeof(Accordion));
 
     /// <summary>
@@ -161,11 +209,27 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         typeof(Accordion));
 
     /// <summary>
+    /// Identifies the <see cref="ClearSelectionCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ClearSelectionCommandParameterProperty = BindableProperty.Create(
+        nameof(ClearSelectionCommandParameter),
+        typeof(object),
+        typeof(Accordion));
+
+    /// <summary>
     /// Identifies the <see cref="SelectionChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectionChangedCommandProperty = BindableProperty.Create(
         nameof(SelectionChangedCommand),
         typeof(ICommand),
+        typeof(Accordion));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectionChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectionChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectionChangedCommandParameter),
+        typeof(object),
         typeof(Accordion));
 
     #endregion
@@ -285,12 +349,32 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ItemExpandedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ItemExpandedCommandParameter
+    {
+        get => GetValue(ItemExpandedCommandParameterProperty);
+        set => SetValue(ItemExpandedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when an item is collapsed.
     /// </summary>
     public ICommand? ItemCollapsedCommand
     {
         get => (ICommand?)GetValue(ItemCollapsedCommandProperty);
         set => SetValue(ItemCollapsedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ItemCollapsedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ItemCollapsedCommandParameter
+    {
+        get => GetValue(ItemCollapsedCommandParameterProperty);
+        set => SetValue(ItemCollapsedCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -300,11 +384,31 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         set => SetValue(GotFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="GotFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? GotFocusCommandParameter
+    {
+        get => GetValue(GotFocusCommandParameterProperty);
+        set => SetValue(GotFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? LostFocusCommand
     {
         get => (ICommand?)GetValue(LostFocusCommandProperty);
         set => SetValue(LostFocusCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LostFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LostFocusCommandParameter
+    {
+        get => GetValue(LostFocusCommandParameterProperty);
+        set => SetValue(LostFocusCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -314,11 +418,31 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         set => SetValue(KeyPressCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="KeyPressCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? KeyPressCommandParameter
+    {
+        get => GetValue(KeyPressCommandParameterProperty);
+        set => SetValue(KeyPressCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? SelectAllCommand
     {
         get => (ICommand?)GetValue(SelectAllCommandProperty);
         set => SetValue(SelectAllCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectAllCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectAllCommandParameter
+    {
+        get => GetValue(SelectAllCommandParameterProperty);
+        set => SetValue(SelectAllCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -328,11 +452,31 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         set => SetValue(ClearSelectionCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ClearSelectionCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ClearSelectionCommandParameter
+    {
+        get => GetValue(ClearSelectionCommandParameterProperty);
+        set => SetValue(ClearSelectionCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? SelectionChangedCommand
     {
         get => (ICommand?)GetValue(SelectionChangedCommandProperty);
         set => SetValue(SelectionChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectionChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectionChangedCommandParameter
+    {
+        get => GetValue(SelectionChangedCommandParameterProperty);
+        set => SetValue(SelectionChangedCommandParameterProperty, value);
     }
 
     #endregion
@@ -398,7 +542,7 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
 
         if (KeyPressCommand?.CanExecute(e) == true)
         {
-            KeyPressCommand.Execute(e);
+            KeyPressCommand.Execute(KeyPressCommandParameter ?? e);
             if (e.Handled) return true;
         }
 
@@ -454,7 +598,7 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         _hasKeyboardFocus = true;
         OnPropertyChanged(nameof(HasKeyboardFocus));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
 
         if (_selectedIndex < 0 && _items.Count > 0)
         {
@@ -592,7 +736,7 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
 
         var args = new Base.SelectionChangedEventArgs(oldValue, newValue);
         SelectionChanged?.Invoke(this, args);
-        SelectionChangedCommand?.Execute(newValue);
+        SelectionChangedCommand?.Execute(SelectionChangedCommandParameter ?? newValue);
 
         OnPropertyChanged(nameof(HasSelection));
         OnPropertyChanged(nameof(IsAllSelected));
@@ -1085,7 +1229,7 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
 
         var args = new AccordionItemExpandedEventArgs(item, item.Index, true);
         ItemExpanded?.Invoke(this, args);
-        ItemExpandedCommand?.Execute(args);
+        ItemExpandedCommand?.Execute(ItemExpandedCommandParameter ?? args);
 
         // Update ISelectable state
         OnPropertyChanged(nameof(HasSelection));
@@ -1119,7 +1263,7 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
 
         var args = new AccordionItemExpandedEventArgs(item, item.Index, false);
         ItemCollapsed?.Invoke(this, args);
-        ItemCollapsedCommand?.Execute(args);
+        ItemCollapsedCommand?.Execute(ItemCollapsedCommandParameter ?? args);
 
         // Update ISelectable state
         OnPropertyChanged(nameof(HasSelection));
@@ -1136,7 +1280,7 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         OnPropertyChanged(nameof(HasKeyboardFocus));
         OnPropertyChanged(nameof(CurrentBorderColor));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
 
         if (_selectedIndex < 0 && _items.Count > 0)
         {
@@ -1150,7 +1294,7 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         OnPropertyChanged(nameof(HasKeyboardFocus));
         OnPropertyChanged(nameof(CurrentBorderColor));
         KeyboardFocusLost?.Invoke(this, new KeyboardFocusEventArgs(false));
-        LostFocusCommand?.Execute(this);
+        LostFocusCommand?.Execute(LostFocusCommandParameter ?? this);
     }
 
     private void OnItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/MauiControlsExtras/Controls/Accordion/AccordionItem.cs
+++ b/src/MauiControlsExtras/Controls/Accordion/AccordionItem.cs
@@ -55,6 +55,14 @@ public class AccordionItem : ContentView
         null);
 
     /// <summary>
+    /// Identifies the <see cref="ExpandCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ExpandCommandParameterProperty = BindableProperty.Create(
+        nameof(ExpandCommandParameter),
+        typeof(object),
+        typeof(AccordionItem));
+
+    /// <summary>
     /// Identifies the <see cref="CollapseCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty CollapseCommandProperty = BindableProperty.Create(
@@ -62,6 +70,14 @@ public class AccordionItem : ContentView
         typeof(ICommand),
         typeof(AccordionItem),
         null);
+
+    /// <summary>
+    /// Identifies the <see cref="CollapseCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CollapseCommandParameterProperty = BindableProperty.Create(
+        nameof(CollapseCommandParameter),
+        typeof(object),
+        typeof(AccordionItem));
 
     /// <summary>
     /// Identifies the <see cref="IsExpanded"/> bindable property.
@@ -133,12 +149,32 @@ public class AccordionItem : ContentView
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ExpandCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ExpandCommandParameter
+    {
+        get => GetValue(ExpandCommandParameterProperty);
+        set => SetValue(ExpandCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when collapsing.
     /// </summary>
     public ICommand? CollapseCommand
     {
         get => (ICommand?)GetValue(CollapseCommandProperty);
         set => SetValue(CollapseCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CollapseCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CollapseCommandParameter
+    {
+        get => GetValue(CollapseCommandParameterProperty);
+        set => SetValue(CollapseCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -192,7 +228,7 @@ public class AccordionItem : ContentView
         {
             IsExpanded = true;
             Expanded?.Invoke(this, EventArgs.Empty);
-            ExpandCommand?.Execute(this);
+            ExpandCommand?.Execute(ExpandCommandParameter ?? this);
         }
     }
 
@@ -205,7 +241,7 @@ public class AccordionItem : ContentView
         {
             IsExpanded = false;
             Collapsed?.Invoke(this, EventArgs.Empty);
-            CollapseCommand?.Execute(this);
+            CollapseCommand?.Execute(CollapseCommandParameter ?? this);
         }
     }
 

--- a/src/MauiControlsExtras/Controls/BindingNavigator/BindingNavigator.xaml.cs
+++ b/src/MauiControlsExtras/Controls/BindingNavigator/BindingNavigator.xaml.cs
@@ -199,11 +199,27 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         typeof(BindingNavigator));
 
     /// <summary>
+    /// Identifies the <see cref="PositionChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PositionChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(PositionChangedCommandParameter),
+        typeof(object),
+        typeof(BindingNavigator));
+
+    /// <summary>
     /// Identifies the <see cref="AddCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty AddCommandProperty = BindableProperty.Create(
         nameof(AddCommand),
         typeof(ICommand),
+        typeof(BindingNavigator));
+
+    /// <summary>
+    /// Identifies the <see cref="AddCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty AddCommandParameterProperty = BindableProperty.Create(
+        nameof(AddCommandParameter),
+        typeof(object),
         typeof(BindingNavigator));
 
     /// <summary>
@@ -215,11 +231,27 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         typeof(BindingNavigator));
 
     /// <summary>
+    /// Identifies the <see cref="DeleteCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty DeleteCommandParameterProperty = BindableProperty.Create(
+        nameof(DeleteCommandParameter),
+        typeof(object),
+        typeof(BindingNavigator));
+
+    /// <summary>
     /// Identifies the <see cref="SaveCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SaveCommandProperty = BindableProperty.Create(
         nameof(SaveCommand),
         typeof(ICommand),
+        typeof(BindingNavigator));
+
+    /// <summary>
+    /// Identifies the <see cref="SaveCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SaveCommandParameterProperty = BindableProperty.Create(
+        nameof(SaveCommandParameter),
+        typeof(object),
         typeof(BindingNavigator));
 
     /// <summary>
@@ -231,11 +263,27 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         typeof(BindingNavigator));
 
     /// <summary>
+    /// Identifies the <see cref="CancelCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CancelCommandParameterProperty = BindableProperty.Create(
+        nameof(CancelCommandParameter),
+        typeof(object),
+        typeof(BindingNavigator));
+
+    /// <summary>
     /// Identifies the <see cref="RefreshCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty RefreshCommandProperty = BindableProperty.Create(
         nameof(RefreshCommand),
         typeof(ICommand),
+        typeof(BindingNavigator));
+
+    /// <summary>
+    /// Identifies the <see cref="RefreshCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty RefreshCommandParameterProperty = BindableProperty.Create(
+        nameof(RefreshCommandParameter),
+        typeof(object),
         typeof(BindingNavigator));
 
     /// <summary>
@@ -247,6 +295,14 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         typeof(BindingNavigator));
 
     /// <summary>
+    /// Identifies the <see cref="GotFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(GotFocusCommandParameter),
+        typeof(object),
+        typeof(BindingNavigator));
+
+    /// <summary>
     /// Identifies the <see cref="LostFocusCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty LostFocusCommandProperty = BindableProperty.Create(
@@ -255,11 +311,27 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         typeof(BindingNavigator));
 
     /// <summary>
+    /// Identifies the <see cref="LostFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(LostFocusCommandParameter),
+        typeof(object),
+        typeof(BindingNavigator));
+
+    /// <summary>
     /// Identifies the <see cref="KeyPressCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty KeyPressCommandProperty = BindableProperty.Create(
         nameof(KeyPressCommand),
         typeof(ICommand),
+        typeof(BindingNavigator));
+
+    /// <summary>
+    /// Identifies the <see cref="KeyPressCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandParameterProperty = BindableProperty.Create(
+        nameof(KeyPressCommandParameter),
+        typeof(object),
         typeof(BindingNavigator));
 
     #endregion
@@ -470,12 +542,32 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="PositionChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? PositionChangedCommandParameter
+    {
+        get => GetValue(PositionChangedCommandParameterProperty);
+        set => SetValue(PositionChangedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when Add is clicked.
     /// </summary>
     public ICommand? AddCommand
     {
         get => (ICommand?)GetValue(AddCommandProperty);
         set => SetValue(AddCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="AddCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? AddCommandParameter
+    {
+        get => GetValue(AddCommandParameterProperty);
+        set => SetValue(AddCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -488,12 +580,32 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="DeleteCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? DeleteCommandParameter
+    {
+        get => GetValue(DeleteCommandParameterProperty);
+        set => SetValue(DeleteCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when Save is clicked.
     /// </summary>
     public ICommand? SaveCommand
     {
         get => (ICommand?)GetValue(SaveCommandProperty);
         set => SetValue(SaveCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SaveCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SaveCommandParameter
+    {
+        get => GetValue(SaveCommandParameterProperty);
+        set => SetValue(SaveCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -506,12 +618,32 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CancelCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CancelCommandParameter
+    {
+        get => GetValue(CancelCommandParameterProperty);
+        set => SetValue(CancelCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when Refresh is clicked.
     /// </summary>
     public ICommand? RefreshCommand
     {
         get => (ICommand?)GetValue(RefreshCommandProperty);
         set => SetValue(RefreshCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="RefreshCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? RefreshCommandParameter
+    {
+        get => GetValue(RefreshCommandParameterProperty);
+        set => SetValue(RefreshCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -521,6 +653,16 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         set => SetValue(GotFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="GotFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? GotFocusCommandParameter
+    {
+        get => GetValue(GotFocusCommandParameterProperty);
+        set => SetValue(GotFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? LostFocusCommand
     {
@@ -528,11 +670,31 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         set => SetValue(LostFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LostFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LostFocusCommandParameter
+    {
+        get => GetValue(LostFocusCommandParameterProperty);
+        set => SetValue(LostFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? KeyPressCommand
     {
         get => (ICommand?)GetValue(KeyPressCommandProperty);
         set => SetValue(KeyPressCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="KeyPressCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? KeyPressCommandParameter
+    {
+        get => GetValue(KeyPressCommandParameterProperty);
+        set => SetValue(KeyPressCommandParameterProperty, value);
     }
 
     #endregion
@@ -617,7 +779,7 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
 
         if (KeyPressCommand?.CanExecute(e) == true)
         {
-            KeyPressCommand.Execute(e);
+            KeyPressCommand.Execute(KeyPressCommandParameter ?? e);
             if (e.Handled) return true;
         }
 
@@ -671,7 +833,7 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         _hasKeyboardFocus = true;
         OnPropertyChanged(nameof(HasKeyboardFocus));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
         return true;
     }
 
@@ -770,7 +932,7 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         Adding?.Invoke(this, args);
         if (!args.Cancel)
         {
-            AddCommand?.Execute(args);
+            AddCommand?.Execute(AddCommandParameter ?? args);
         }
     }
 
@@ -785,7 +947,7 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
         Deleting?.Invoke(this, args);
         if (!args.Cancel)
         {
-            DeleteCommand?.Execute(args);
+            DeleteCommand?.Execute(DeleteCommandParameter ?? args);
         }
     }
 
@@ -795,7 +957,7 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
     public void Refresh()
     {
         Refreshing?.Invoke(this, EventArgs.Empty);
-        RefreshCommand?.Execute(null);
+        RefreshCommand?.Execute(RefreshCommandParameter);
         UpdateCount();
         UpdateButtonStates();
     }
@@ -815,13 +977,13 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
     private void OnSaveClicked(object? sender, EventArgs e)
     {
         Saving?.Invoke(this, EventArgs.Empty);
-        SaveCommand?.Execute(null);
+        SaveCommand?.Execute(SaveCommandParameter);
     }
 
     private void OnCancelClicked(object? sender, EventArgs e)
     {
         Cancelling?.Invoke(this, EventArgs.Empty);
-        CancelCommand?.Execute(null);
+        CancelCommand?.Execute(CancelCommandParameter);
     }
 
     private void OnPositionEntryCompleted(object? sender, EventArgs e)
@@ -883,7 +1045,7 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
 
             var args = new PositionChangedEventArgs(oldPos, newPos, navigator.CurrentItem);
             navigator.PositionChanged?.Invoke(navigator, args);
-            navigator.PositionChangedCommand?.Execute(args);
+            navigator.PositionChangedCommand?.Execute(navigator.PositionChangedCommandParameter ?? args);
         }
     }
 

--- a/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml.cs
@@ -167,11 +167,27 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         typeof(Breadcrumb));
 
     /// <summary>
+    /// Identifies the <see cref="ItemClickedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ItemClickedCommandParameterProperty = BindableProperty.Create(
+        nameof(ItemClickedCommandParameter),
+        typeof(object),
+        typeof(Breadcrumb));
+
+    /// <summary>
     /// Identifies the <see cref="HomeClickedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty HomeClickedCommandProperty = BindableProperty.Create(
         nameof(HomeClickedCommand),
         typeof(ICommand),
+        typeof(Breadcrumb));
+
+    /// <summary>
+    /// Identifies the <see cref="HomeClickedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty HomeClickedCommandParameterProperty = BindableProperty.Create(
+        nameof(HomeClickedCommandParameter),
+        typeof(object),
         typeof(Breadcrumb));
 
     /// <summary>
@@ -183,11 +199,27 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         typeof(Breadcrumb));
 
     /// <summary>
+    /// Identifies the <see cref="GotFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(GotFocusCommandParameter),
+        typeof(object),
+        typeof(Breadcrumb));
+
+    /// <summary>
     /// Identifies the <see cref="LostFocusCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty LostFocusCommandProperty = BindableProperty.Create(
         nameof(LostFocusCommand),
         typeof(ICommand),
+        typeof(Breadcrumb));
+
+    /// <summary>
+    /// Identifies the <see cref="LostFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(LostFocusCommandParameter),
+        typeof(object),
         typeof(Breadcrumb));
 
     /// <summary>
@@ -199,11 +231,27 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         typeof(Breadcrumb));
 
     /// <summary>
+    /// Identifies the <see cref="KeyPressCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandParameterProperty = BindableProperty.Create(
+        nameof(KeyPressCommandParameter),
+        typeof(object),
+        typeof(Breadcrumb));
+
+    /// <summary>
     /// Identifies the <see cref="SelectAllCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectAllCommandProperty = BindableProperty.Create(
         nameof(SelectAllCommand),
         typeof(ICommand),
+        typeof(Breadcrumb));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectAllCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectAllCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectAllCommandParameter),
+        typeof(object),
         typeof(Breadcrumb));
 
     /// <summary>
@@ -215,11 +263,27 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         typeof(Breadcrumb));
 
     /// <summary>
+    /// Identifies the <see cref="ClearSelectionCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ClearSelectionCommandParameterProperty = BindableProperty.Create(
+        nameof(ClearSelectionCommandParameter),
+        typeof(object),
+        typeof(Breadcrumb));
+
+    /// <summary>
     /// Identifies the <see cref="SelectionChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectionChangedCommandProperty = BindableProperty.Create(
         nameof(SelectionChangedCommand),
         typeof(ICommand),
+        typeof(Breadcrumb));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectionChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectionChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectionChangedCommandParameter),
+        typeof(object),
         typeof(Breadcrumb));
 
     /// <summary>
@@ -403,12 +467,32 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ItemClickedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ItemClickedCommandParameter
+    {
+        get => GetValue(ItemClickedCommandParameterProperty);
+        set => SetValue(ItemClickedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when the home icon is clicked.
     /// </summary>
     public ICommand? HomeClickedCommand
     {
         get => (ICommand?)GetValue(HomeClickedCommandProperty);
         set => SetValue(HomeClickedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="HomeClickedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? HomeClickedCommandParameter
+    {
+        get => GetValue(HomeClickedCommandParameterProperty);
+        set => SetValue(HomeClickedCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -418,11 +502,31 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         set => SetValue(GotFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="GotFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? GotFocusCommandParameter
+    {
+        get => GetValue(GotFocusCommandParameterProperty);
+        set => SetValue(GotFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? LostFocusCommand
     {
         get => (ICommand?)GetValue(LostFocusCommandProperty);
         set => SetValue(LostFocusCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LostFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LostFocusCommandParameter
+    {
+        get => GetValue(LostFocusCommandParameterProperty);
+        set => SetValue(LostFocusCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -432,11 +536,31 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         set => SetValue(KeyPressCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="KeyPressCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? KeyPressCommandParameter
+    {
+        get => GetValue(KeyPressCommandParameterProperty);
+        set => SetValue(KeyPressCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? SelectAllCommand
     {
         get => (ICommand?)GetValue(SelectAllCommandProperty);
         set => SetValue(SelectAllCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectAllCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectAllCommandParameter
+    {
+        get => GetValue(SelectAllCommandParameterProperty);
+        set => SetValue(SelectAllCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -446,11 +570,31 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         set => SetValue(ClearSelectionCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ClearSelectionCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ClearSelectionCommandParameter
+    {
+        get => GetValue(ClearSelectionCommandParameterProperty);
+        set => SetValue(ClearSelectionCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? SelectionChangedCommand
     {
         get => (ICommand?)GetValue(SelectionChangedCommandProperty);
         set => SetValue(SelectionChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectionChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectionChangedCommandParameter
+    {
+        get => GetValue(SelectionChangedCommandParameterProperty);
+        set => SetValue(SelectionChangedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -537,7 +681,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
 
         if (KeyPressCommand?.CanExecute(e) == true)
         {
-            KeyPressCommand.Execute(e);
+            KeyPressCommand.Execute(KeyPressCommandParameter ?? e);
             if (e.Handled) return true;
         }
 
@@ -585,7 +729,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         _hasKeyboardFocus = true;
         OnPropertyChanged(nameof(HasKeyboardFocus));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
 
         if (_selectedIndex < 0 && _items.Count > 0)
         {
@@ -628,7 +772,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
     {
         // No-op for breadcrumb - selecting all items doesn't make sense
         // for a navigation trail where only one location is "current"
-        SelectAllCommand?.Execute(null);
+        SelectAllCommand?.Execute(SelectAllCommandParameter);
     }
 
     /// <inheritdoc/>
@@ -640,7 +784,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
     {
         if (_items.Count <= 1)
         {
-            ClearSelectionCommand?.Execute(null);
+            ClearSelectionCommand?.Execute(ClearSelectionCommandParameter);
             return;
         }
 
@@ -657,7 +801,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
             RaiseSelectionChanged(oldSelection, newSelection);
         }
 
-        ClearSelectionCommand?.Execute(null);
+        ClearSelectionCommand?.Execute(ClearSelectionCommandParameter);
     }
 
     /// <inheritdoc/>
@@ -718,7 +862,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
 
         if (SelectionChangedCommand?.CanExecute(newSelection) == true)
         {
-            SelectionChangedCommand.Execute(newSelection);
+            SelectionChangedCommand.Execute(SelectionChangedCommandParameter ?? newSelection);
         }
     }
 
@@ -920,7 +1064,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         tapGesture.Tapped += (s, e) =>
         {
             HomeClicked?.Invoke(this, EventArgs.Empty);
-            HomeClickedCommand?.Execute(null);
+            HomeClickedCommand?.Execute(HomeClickedCommandParameter);
         };
         label.GestureRecognizers.Add(tapGesture);
 
@@ -1032,7 +1176,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
 
         var args = new BreadcrumbItemClickedEventArgs(item, index);
         ItemClicked?.Invoke(this, args);
-        ItemClickedCommand?.Execute(args);
+        ItemClickedCommand?.Execute(ItemClickedCommandParameter ?? args);
     }
 
     private void OnControlFocused(object? sender, FocusEventArgs e)
@@ -1041,7 +1185,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         OnPropertyChanged(nameof(HasKeyboardFocus));
         OnPropertyChanged(nameof(CurrentBorderColor));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
 
         if (_selectedIndex < 0 && _items.Count > 0)
         {
@@ -1057,7 +1201,7 @@ public partial class Breadcrumb : StyledControlBase, IKeyboardNavigable, ISelect
         OnPropertyChanged(nameof(HasKeyboardFocus));
         OnPropertyChanged(nameof(CurrentBorderColor));
         KeyboardFocusLost?.Invoke(this, new KeyboardFocusEventArgs(false));
-        LostFocusCommand?.Execute(this);
+        LostFocusCommand?.Execute(LostFocusCommandParameter ?? this);
         RebuildUI();
     }
 

--- a/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml.cs
@@ -148,11 +148,27 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         typeof(Calendar));
 
     /// <summary>
+    /// Identifies the <see cref="DateSelectedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty DateSelectedCommandParameterProperty = BindableProperty.Create(
+        nameof(DateSelectedCommandParameter),
+        typeof(object),
+        typeof(Calendar));
+
+    /// <summary>
     /// Identifies the <see cref="DisplayDateChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty DisplayDateChangedCommandProperty = BindableProperty.Create(
         nameof(DisplayDateChangedCommand),
         typeof(ICommand),
+        typeof(Calendar));
+
+    /// <summary>
+    /// Identifies the <see cref="DisplayDateChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty DisplayDateChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(DisplayDateChangedCommandParameter),
+        typeof(object),
         typeof(Calendar));
 
     /// <summary>
@@ -164,11 +180,27 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         typeof(Calendar));
 
     /// <summary>
+    /// Identifies the <see cref="GotFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(GotFocusCommandParameter),
+        typeof(object),
+        typeof(Calendar));
+
+    /// <summary>
     /// Identifies the <see cref="LostFocusCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty LostFocusCommandProperty = BindableProperty.Create(
         nameof(LostFocusCommand),
         typeof(ICommand),
+        typeof(Calendar));
+
+    /// <summary>
+    /// Identifies the <see cref="LostFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(LostFocusCommandParameter),
+        typeof(object),
         typeof(Calendar));
 
     /// <summary>
@@ -180,11 +212,27 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         typeof(Calendar));
 
     /// <summary>
+    /// Identifies the <see cref="KeyPressCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandParameterProperty = BindableProperty.Create(
+        nameof(KeyPressCommandParameter),
+        typeof(object),
+        typeof(Calendar));
+
+    /// <summary>
     /// Identifies the <see cref="SelectAllCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectAllCommandProperty = BindableProperty.Create(
         nameof(SelectAllCommand),
         typeof(ICommand),
+        typeof(Calendar));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectAllCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectAllCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectAllCommandParameter),
+        typeof(object),
         typeof(Calendar));
 
     /// <summary>
@@ -196,11 +244,27 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         typeof(Calendar));
 
     /// <summary>
+    /// Identifies the <see cref="ClearSelectionCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ClearSelectionCommandParameterProperty = BindableProperty.Create(
+        nameof(ClearSelectionCommandParameter),
+        typeof(object),
+        typeof(Calendar));
+
+    /// <summary>
     /// Identifies the <see cref="SelectionChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectionChangedCommandProperty = BindableProperty.Create(
         nameof(SelectionChangedCommand),
         typeof(ICommand),
+        typeof(Calendar));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectionChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectionChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectionChangedCommandParameter),
+        typeof(object),
         typeof(Calendar));
 
     #endregion
@@ -333,12 +397,32 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="DateSelectedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? DateSelectedCommandParameter
+    {
+        get => GetValue(DateSelectedCommandParameterProperty);
+        set => SetValue(DateSelectedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when the display date changes.
     /// </summary>
     public ICommand? DisplayDateChangedCommand
     {
         get => (ICommand?)GetValue(DisplayDateChangedCommandProperty);
         set => SetValue(DisplayDateChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="DisplayDateChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? DisplayDateChangedCommandParameter
+    {
+        get => GetValue(DisplayDateChangedCommandParameterProperty);
+        set => SetValue(DisplayDateChangedCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -348,11 +432,31 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         set => SetValue(GotFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="GotFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? GotFocusCommandParameter
+    {
+        get => GetValue(GotFocusCommandParameterProperty);
+        set => SetValue(GotFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? LostFocusCommand
     {
         get => (ICommand?)GetValue(LostFocusCommandProperty);
         set => SetValue(LostFocusCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LostFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LostFocusCommandParameter
+    {
+        get => GetValue(LostFocusCommandParameterProperty);
+        set => SetValue(LostFocusCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -362,11 +466,31 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         set => SetValue(KeyPressCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="KeyPressCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? KeyPressCommandParameter
+    {
+        get => GetValue(KeyPressCommandParameterProperty);
+        set => SetValue(KeyPressCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? SelectAllCommand
     {
         get => (ICommand?)GetValue(SelectAllCommandProperty);
         set => SetValue(SelectAllCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectAllCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectAllCommandParameter
+    {
+        get => GetValue(SelectAllCommandParameterProperty);
+        set => SetValue(SelectAllCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -376,11 +500,31 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         set => SetValue(ClearSelectionCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ClearSelectionCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ClearSelectionCommandParameter
+    {
+        get => GetValue(ClearSelectionCommandParameterProperty);
+        set => SetValue(ClearSelectionCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? SelectionChangedCommand
     {
         get => (ICommand?)GetValue(SelectionChangedCommandProperty);
         set => SetValue(SelectionChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectionChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectionChangedCommandParameter
+    {
+        get => GetValue(SelectionChangedCommandParameterProperty);
+        set => SetValue(SelectionChangedCommandParameterProperty, value);
     }
 
     #endregion
@@ -448,7 +592,7 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
 
         if (KeyPressCommand?.CanExecute(e) == true)
         {
-            KeyPressCommand.Execute(e);
+            KeyPressCommand.Execute(KeyPressCommandParameter ?? e);
             if (e.Handled) return true;
         }
 
@@ -505,7 +649,7 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         _hasKeyboardFocus = true;
         OnPropertyChanged(nameof(HasKeyboardFocus));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
         RebuildCalendar();
         return true;
     }
@@ -662,7 +806,7 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
 
         var args = new Base.SelectionChangedEventArgs(oldValue, newValue);
         SelectionChanged?.Invoke(this, args);
-        SelectionChangedCommand?.Execute(newValue);
+        SelectionChangedCommand?.Execute(SelectionChangedCommandParameter ?? newValue);
 
         OnPropertyChanged(nameof(HasSelection));
         OnPropertyChanged(nameof(IsAllSelected));
@@ -742,7 +886,7 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
 
         var args = new CalendarDisplayDateChangedEventArgs(oldDate, _displayDate);
         DisplayDateChanged?.Invoke(this, args);
-        DisplayDateChangedCommand?.Execute(args);
+        DisplayDateChangedCommand?.Execute(DisplayDateChangedCommandParameter ?? args);
     }
 
     /// <summary>
@@ -757,7 +901,7 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
 
         var args = new CalendarDisplayDateChangedEventArgs(oldDate, _displayDate);
         DisplayDateChanged?.Invoke(this, args);
-        DisplayDateChangedCommand?.Execute(args);
+        DisplayDateChangedCommand?.Execute(DisplayDateChangedCommandParameter ?? args);
     }
 
     /// <summary>
@@ -774,7 +918,7 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         {
             var args = new CalendarDisplayDateChangedEventArgs(oldDate, _displayDate);
             DisplayDateChanged?.Invoke(this, args);
-            DisplayDateChangedCommand?.Execute(args);
+            DisplayDateChangedCommand?.Execute(DisplayDateChangedCommandParameter ?? args);
         }
     }
 
@@ -877,7 +1021,7 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
 
         var selectedArgs = new CalendarDateSelectedEventArgs(normalizedDate, true);
         DateSelected?.Invoke(this, selectedArgs);
-        DateSelectedCommand?.Execute(selectedArgs);
+        DateSelectedCommand?.Execute(DateSelectedCommandParameter ?? selectedArgs);
 
         // Raise ISelectable events
         RaiseSelectionChanged(oldSelection, _selectedDates.ToList());

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -515,11 +515,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="SelectionChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectionChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectionChangedCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="CellTappedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty CellTappedCommandProperty = BindableProperty.Create(
         nameof(CellTappedCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="CellTappedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CellTappedCommandParameterProperty = BindableProperty.Create(
+        nameof(CellTappedCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -531,11 +547,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="CellDoubleTappedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CellDoubleTappedCommandParameterProperty = BindableProperty.Create(
+        nameof(CellDoubleTappedCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="SortingCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SortingCommandProperty = BindableProperty.Create(
         nameof(SortingCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="SortingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SortingCommandParameterProperty = BindableProperty.Create(
+        nameof(SortingCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -547,11 +579,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="SortedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SortedCommandParameterProperty = BindableProperty.Create(
+        nameof(SortedCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="CellEditStartedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty CellEditStartedCommandProperty = BindableProperty.Create(
         nameof(CellEditStartedCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="CellEditStartedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CellEditStartedCommandParameterProperty = BindableProperty.Create(
+        nameof(CellEditStartedCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -563,11 +611,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="CellEditEndedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CellEditEndedCommandParameterProperty = BindableProperty.Create(
+        nameof(CellEditEndedCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="CellEditCancelledCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty CellEditCancelledCommandProperty = BindableProperty.Create(
         nameof(CellEditCancelledCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="CellEditCancelledCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CellEditCancelledCommandParameterProperty = BindableProperty.Create(
+        nameof(CellEditCancelledCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -579,11 +643,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="RowEditEndedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty RowEditEndedCommandParameterProperty = BindableProperty.Create(
+        nameof(RowEditEndedCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="FilteringCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty FilteringCommandProperty = BindableProperty.Create(
         nameof(FilteringCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="FilteringCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty FilteringCommandParameterProperty = BindableProperty.Create(
+        nameof(FilteringCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -595,11 +675,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="FilteredCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty FilteredCommandParameterProperty = BindableProperty.Create(
+        nameof(FilteredCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="PageChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty PageChangedCommandProperty = BindableProperty.Create(
         nameof(PageChangedCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="PageChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PageChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(PageChangedCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -611,11 +707,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="ExportCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ExportCommandParameterProperty = BindableProperty.Create(
+        nameof(ExportCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="UndoCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty UndoCommandProperty = BindableProperty.Create(
         nameof(UndoCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="UndoCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty UndoCommandParameterProperty = BindableProperty.Create(
+        nameof(UndoCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -627,11 +739,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="RedoCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty RedoCommandParameterProperty = BindableProperty.Create(
+        nameof(RedoCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="CopyCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty CopyCommandProperty = BindableProperty.Create(
         nameof(CopyCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="CopyCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CopyCommandParameterProperty = BindableProperty.Create(
+        nameof(CopyCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -643,11 +771,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="CutCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CutCommandParameterProperty = BindableProperty.Create(
+        nameof(CutCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="PasteCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty PasteCommandProperty = BindableProperty.Create(
         nameof(PasteCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="PasteCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PasteCommandParameterProperty = BindableProperty.Create(
+        nameof(PasteCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -659,11 +803,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="ColumnReorderedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ColumnReorderedCommandParameterProperty = BindableProperty.Create(
+        nameof(ColumnReorderedCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="RowSelectedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty RowSelectedCommandProperty = BindableProperty.Create(
         nameof(RowSelectedCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="RowSelectedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty RowSelectedCommandParameterProperty = BindableProperty.Create(
+        nameof(RowSelectedCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -675,6 +835,14 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="RowDeselectedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty RowDeselectedCommandParameterProperty = BindableProperty.Create(
+        nameof(RowDeselectedCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="SelectAllCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectAllCommandProperty = BindableProperty.Create(
@@ -683,11 +851,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="SelectAllCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectAllCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectAllCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="ClearSelectionCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty ClearSelectionCommandProperty = BindableProperty.Create(
         nameof(ClearSelectionCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="ClearSelectionCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ClearSelectionCommandParameterProperty = BindableProperty.Create(
+        nameof(ClearSelectionCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -1144,12 +1328,32 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectionChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectionChangedCommandParameter
+    {
+        get => GetValue(SelectionChangedCommandParameterProperty);
+        set => SetValue(SelectionChangedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command to execute when a cell is tapped.
     /// </summary>
     public ICommand? CellTappedCommand
     {
         get => (ICommand?)GetValue(CellTappedCommandProperty);
         set => SetValue(CellTappedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CellTappedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CellTappedCommandParameter
+    {
+        get => GetValue(CellTappedCommandParameterProperty);
+        set => SetValue(CellTappedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1162,12 +1366,32 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CellDoubleTappedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CellDoubleTappedCommandParameter
+    {
+        get => GetValue(CellDoubleTappedCommandParameterProperty);
+        set => SetValue(CellDoubleTappedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command to execute before sorting.
     /// </summary>
     public ICommand? SortingCommand
     {
         get => (ICommand?)GetValue(SortingCommandProperty);
         set => SetValue(SortingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SortingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SortingCommandParameter
+    {
+        get => GetValue(SortingCommandParameterProperty);
+        set => SetValue(SortingCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1180,12 +1404,32 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SortedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SortedCommandParameter
+    {
+        get => GetValue(SortedCommandParameterProperty);
+        set => SetValue(SortedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command to execute when cell edit starts.
     /// </summary>
     public ICommand? CellEditStartedCommand
     {
         get => (ICommand?)GetValue(CellEditStartedCommandProperty);
         set => SetValue(CellEditStartedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CellEditStartedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CellEditStartedCommandParameter
+    {
+        get => GetValue(CellEditStartedCommandParameterProperty);
+        set => SetValue(CellEditStartedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1198,12 +1442,32 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CellEditEndedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CellEditEndedCommandParameter
+    {
+        get => GetValue(CellEditEndedCommandParameterProperty);
+        set => SetValue(CellEditEndedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command to execute when cell edit is cancelled (e.g., user presses Escape).
     /// </summary>
     public ICommand? CellEditCancelledCommand
     {
         get => (ICommand?)GetValue(CellEditCancelledCommandProperty);
         set => SetValue(CellEditCancelledCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CellEditCancelledCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CellEditCancelledCommandParameter
+    {
+        get => GetValue(CellEditCancelledCommandParameterProperty);
+        set => SetValue(CellEditCancelledCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1216,12 +1480,32 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="RowEditEndedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? RowEditEndedCommandParameter
+    {
+        get => GetValue(RowEditEndedCommandParameterProperty);
+        set => SetValue(RowEditEndedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command to execute before filtering.
     /// </summary>
     public ICommand? FilteringCommand
     {
         get => (ICommand?)GetValue(FilteringCommandProperty);
         set => SetValue(FilteringCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="FilteringCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? FilteringCommandParameter
+    {
+        get => GetValue(FilteringCommandParameterProperty);
+        set => SetValue(FilteringCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1234,12 +1518,32 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="FilteredCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? FilteredCommandParameter
+    {
+        get => GetValue(FilteredCommandParameterProperty);
+        set => SetValue(FilteredCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command to execute when page changes.
     /// </summary>
     public ICommand? PageChangedCommand
     {
         get => (ICommand?)GetValue(PageChangedCommandProperty);
         set => SetValue(PageChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="PageChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? PageChangedCommandParameter
+    {
+        get => GetValue(PageChangedCommandParameterProperty);
+        set => SetValue(PageChangedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1251,11 +1555,31 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         set => SetValue(ExportCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ExportCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ExportCommandParameter
+    {
+        get => GetValue(ExportCommandParameterProperty);
+        set => SetValue(ExportCommandParameterProperty, value);
+    }
+
     /// <inheritdoc />
     public ICommand? UndoCommand
     {
         get => (ICommand?)GetValue(UndoCommandProperty);
         set => SetValue(UndoCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="UndoCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? UndoCommandParameter
+    {
+        get => GetValue(UndoCommandParameterProperty);
+        set => SetValue(UndoCommandParameterProperty, value);
     }
 
     /// <inheritdoc />
@@ -1265,11 +1589,31 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         set => SetValue(RedoCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="RedoCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? RedoCommandParameter
+    {
+        get => GetValue(RedoCommandParameterProperty);
+        set => SetValue(RedoCommandParameterProperty, value);
+    }
+
     /// <inheritdoc />
     public ICommand? CopyCommand
     {
         get => (ICommand?)GetValue(CopyCommandProperty);
         set => SetValue(CopyCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CopyCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CopyCommandParameter
+    {
+        get => GetValue(CopyCommandParameterProperty);
+        set => SetValue(CopyCommandParameterProperty, value);
     }
 
     /// <inheritdoc />
@@ -1279,11 +1623,31 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         set => SetValue(CutCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CutCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CutCommandParameter
+    {
+        get => GetValue(CutCommandParameterProperty);
+        set => SetValue(CutCommandParameterProperty, value);
+    }
+
     /// <inheritdoc />
     public ICommand? PasteCommand
     {
         get => (ICommand?)GetValue(PasteCommandProperty);
         set => SetValue(PasteCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="PasteCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? PasteCommandParameter
+    {
+        get => GetValue(PasteCommandParameterProperty);
+        set => SetValue(PasteCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1297,6 +1661,16 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ColumnReorderedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ColumnReorderedCommandParameter
+    {
+        get => GetValue(ColumnReorderedCommandParameterProperty);
+        set => SetValue(ColumnReorderedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when a row is selected.
     /// The command parameter is <see cref="DataGridRowSelectionEventArgs"/>.
     /// </summary>
@@ -1304,6 +1678,16 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     {
         get => (ICommand?)GetValue(RowSelectedCommandProperty);
         set => SetValue(RowSelectedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="RowSelectedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? RowSelectedCommandParameter
+    {
+        get => GetValue(RowSelectedCommandParameterProperty);
+        set => SetValue(RowSelectedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1317,6 +1701,16 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="RowDeselectedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? RowDeselectedCommandParameter
+    {
+        get => GetValue(RowDeselectedCommandParameterProperty);
+        set => SetValue(RowDeselectedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command to execute for select all operations.
     /// </summary>
     public ICommand? SelectAllCommand
@@ -1326,12 +1720,32 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectAllCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectAllCommandParameter
+    {
+        get => GetValue(SelectAllCommandParameterProperty);
+        set => SetValue(SelectAllCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command to execute for clear selection operations.
     /// </summary>
     public ICommand? ClearSelectionCommand
     {
         get => (ICommand?)GetValue(ClearSelectionCommandProperty);
         set => SetValue(ClearSelectionCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ClearSelectionCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ClearSelectionCommandParameter
+    {
+        get => GetValue(ClearSelectionCommandParameterProperty);
+        set => SetValue(ClearSelectionCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1819,7 +2233,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         Exported?.Invoke(this, args);
 
         if (ExportCommand?.CanExecute(args) == true)
-            ExportCommand.Execute(args);
+            ExportCommand.Execute(ExportCommandParameter ?? args);
 
         return result;
     }
@@ -1857,7 +2271,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         Exported?.Invoke(this, args);
 
         if (ExportCommand?.CanExecute(args) == true)
-            ExportCommand.Execute(args);
+            ExportCommand.Execute(ExportCommandParameter ?? args);
 
         return result;
     }
@@ -2441,8 +2855,9 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         args.Content = content;
         Clipboard.Default.SetTextAsync(content);
 
-        if (CopyCommand?.CanExecute(args) == true)
-            CopyCommand.Execute(args);
+        var copyParam = CopyCommandParameter ?? args;
+        if (CopyCommand?.CanExecute(copyParam) == true)
+            CopyCommand.Execute(copyParam);
     }
 
     /// <inheritdoc />
@@ -2533,7 +2948,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
             EndBatchOperation();
 
             if (PasteCommand?.CanExecute(args) == true)
-                PasteCommand.Execute(args);
+                PasteCommand.Execute(PasteCommandParameter ?? args);
 
             RefreshData();
         }
@@ -3796,7 +4211,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (SortingCommand?.CanExecute(sortingArgs) == true)
         {
-            SortingCommand.Execute(sortingArgs);
+            SortingCommand.Execute(SortingCommandParameter ?? sortingArgs);
         }
 
         if (sortingArgs.Cancel)
@@ -3828,7 +4243,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (SortedCommand?.CanExecute(column) == true)
         {
-            SortedCommand.Execute(column);
+            SortedCommand.Execute(SortedCommandParameter ?? column);
         }
     }
 
@@ -4103,7 +4518,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (CellEditStartedCommand?.CanExecute(startedArgs) == true)
         {
-            CellEditStartedCommand.Execute(startedArgs);
+            CellEditStartedCommand.Execute(CellEditStartedCommandParameter ?? startedArgs);
         }
     }
 
@@ -4163,7 +4578,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (CellEditEndedCommand?.CanExecute(endedArgs) == true)
         {
-            CellEditEndedCommand.Execute(endedArgs);
+            CellEditEndedCommand.Execute(CellEditEndedCommandParameter ?? endedArgs);
         }
 
         EndEdit();
@@ -4185,7 +4600,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
             if (CellEditCancelledCommand?.CanExecute(cancelledArgs) == true)
             {
-                CellEditCancelledCommand.Execute(cancelledArgs);
+                CellEditCancelledCommand.Execute(CellEditCancelledCommandParameter ?? cancelledArgs);
             }
         }
 
@@ -4232,7 +4647,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
             if (RowEditEndedCommand?.CanExecute(rowArgs) == true)
             {
-                RowEditEndedCommand.Execute(rowArgs);
+                RowEditEndedCommand.Execute(RowEditEndedCommandParameter ?? rowArgs);
             }
 
             _editedColumnsInRow.Clear();
@@ -4770,7 +5185,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (PageChangedCommand?.CanExecute(args) == true)
         {
-            PageChangedCommand.Execute(args);
+            PageChangedCommand.Execute(PageChangedCommandParameter ?? args);
         }
     }
 
@@ -4960,7 +5375,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
             if (ColumnReorderedCommand?.CanExecute(args) == true)
             {
-                ColumnReorderedCommand.Execute(args);
+                ColumnReorderedCommand.Execute(ColumnReorderedCommandParameter ?? args);
             }
 
             BuildGrid();
@@ -5042,7 +5457,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (CellTappedCommand?.CanExecute(args) == true)
         {
-            CellTappedCommand.Execute(args);
+            CellTappedCommand.Execute(CellTappedCommandParameter ?? args);
         }
 
         // Check if we should begin edit
@@ -5065,7 +5480,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (CellDoubleTappedCommand?.CanExecute(args) == true)
         {
-            CellDoubleTappedCommand.Execute(args);
+            CellDoubleTappedCommand.Execute(CellDoubleTappedCommandParameter ?? args);
         }
 
         // Check if we should begin edit
@@ -5141,7 +5556,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (FilteringCommand?.CanExecute(filteringArgs) == true)
         {
-            FilteringCommand.Execute(filteringArgs);
+            FilteringCommand.Execute(FilteringCommandParameter ?? filteringArgs);
         }
 
         if (filteringArgs.Cancel)
@@ -5186,7 +5601,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (FilteredCommand?.CanExecute(filteredArgs) == true)
         {
-            FilteredCommand.Execute(filteredArgs);
+            FilteredCommand.Execute(FilteredCommandParameter ?? filteredArgs);
         }
     }
 
@@ -5438,7 +5853,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (SelectionChangedCommand?.CanExecute(newSelection) == true)
         {
-            SelectionChangedCommand.Execute(newSelection);
+            SelectionChangedCommand.Execute(SelectionChangedCommandParameter ?? newSelection);
         }
     }
 
@@ -5449,7 +5864,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (RowSelectedCommand?.CanExecute(args) == true)
         {
-            RowSelectedCommand.Execute(args);
+            RowSelectedCommand.Execute(RowSelectedCommandParameter ?? args);
         }
     }
 
@@ -5460,7 +5875,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (RowDeselectedCommand?.CanExecute(args) == true)
         {
-            RowDeselectedCommand.Execute(args);
+            RowDeselectedCommand.Execute(RowDeselectedCommandParameter ?? args);
         }
     }
 
@@ -5497,11 +5912,27 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="GotFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(GotFocusCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the LostFocusCommand bindable property.
     /// </summary>
     public static readonly BindableProperty LostFocusCommandProperty = BindableProperty.Create(
         nameof(LostFocusCommand),
         typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="LostFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(LostFocusCommandParameter),
+        typeof(object),
         typeof(DataGridView));
 
     /// <summary>
@@ -5512,11 +5943,29 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(ICommand),
         typeof(DataGridView));
 
+    /// <summary>
+    /// Identifies the <see cref="KeyPressCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandParameterProperty = BindableProperty.Create(
+        nameof(KeyPressCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
     /// <inheritdoc />
     public ICommand? GotFocusCommand
     {
         get => (ICommand?)GetValue(GotFocusCommandProperty);
         set => SetValue(GotFocusCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="GotFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? GotFocusCommandParameter
+    {
+        get => GetValue(GotFocusCommandParameterProperty);
+        set => SetValue(GotFocusCommandParameterProperty, value);
     }
 
     /// <inheritdoc />
@@ -5526,11 +5975,31 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         set => SetValue(LostFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LostFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LostFocusCommandParameter
+    {
+        get => GetValue(LostFocusCommandParameterProperty);
+        set => SetValue(LostFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc />
     public ICommand? KeyPressCommand
     {
         get => (ICommand?)GetValue(KeyPressCommandProperty);
         set => SetValue(KeyPressCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="KeyPressCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? KeyPressCommandParameter
+    {
+        get => GetValue(KeyPressCommandParameterProperty);
+        set => SetValue(KeyPressCommandParameterProperty, value);
     }
 
     /// <inheritdoc />
@@ -5561,7 +6030,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         // Execute command if set
         if (KeyPressCommand?.CanExecute(e) == true)
         {
-            KeyPressCommand.Execute(e);
+            KeyPressCommand.Execute(KeyPressCommandParameter ?? e);
             if (e.Handled) return true;
         }
 
@@ -5646,7 +6115,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         if (result)
         {
             KeyboardFocusGained?.Invoke(this, new Base.KeyboardFocusEventArgs(true));
-            GotFocusCommand?.Execute(this);
+            GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
 
             // If no current cell, select first cell
             if (_focusedRowIndex < 0 && _sortedItems?.Count > 0)
@@ -6097,7 +6566,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     {
         if (ClearSelectionCommand?.CanExecute(null) == true)
         {
-            ClearSelectionCommand.Execute(null);
+            ClearSelectionCommand.Execute(ClearSelectionCommandParameter);
             return;
         }
 
@@ -6124,7 +6593,7 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         if (SelectAllCommand?.CanExecute(null) == true)
         {
-            SelectAllCommand.Execute(null);
+            SelectAllCommand.Execute(SelectAllCommandParameter);
             return;
         }
 

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml.cs
@@ -123,11 +123,27 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         typeof(PropertyGrid));
 
     /// <summary>
+    /// Identifies the <see cref="PropertyChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PropertyChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(PropertyChangedCommandParameter),
+        typeof(object),
+        typeof(PropertyGrid));
+
+    /// <summary>
     /// Identifies the <see cref="SelectedObjectChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectedObjectChangedCommandProperty = BindableProperty.Create(
         nameof(SelectedObjectChangedCommand),
         typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectedObjectChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectedObjectChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectedObjectChangedCommandParameter),
+        typeof(object),
         typeof(PropertyGrid));
 
     /// <summary>
@@ -139,11 +155,27 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         typeof(PropertyGrid));
 
     /// <summary>
+    /// Identifies the <see cref="PropertySelectionChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PropertySelectionChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(PropertySelectionChangedCommandParameter),
+        typeof(object),
+        typeof(PropertyGrid));
+
+    /// <summary>
     /// Identifies the <see cref="GotFocusCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty GotFocusCommandProperty = BindableProperty.Create(
         nameof(GotFocusCommand),
         typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="GotFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(GotFocusCommandParameter),
+        typeof(object),
         typeof(PropertyGrid));
 
     /// <summary>
@@ -155,11 +187,27 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         typeof(PropertyGrid));
 
     /// <summary>
+    /// Identifies the <see cref="LostFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(LostFocusCommandParameter),
+        typeof(object),
+        typeof(PropertyGrid));
+
+    /// <summary>
     /// Identifies the <see cref="KeyPressCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty KeyPressCommandProperty = BindableProperty.Create(
         nameof(KeyPressCommand),
         typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="KeyPressCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandParameterProperty = BindableProperty.Create(
+        nameof(KeyPressCommandParameter),
+        typeof(object),
         typeof(PropertyGrid));
 
     #endregion
@@ -267,12 +315,32 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="PropertyChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? PropertyChangedCommandParameter
+    {
+        get => GetValue(PropertyChangedCommandParameterProperty);
+        set => SetValue(PropertyChangedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when the selected object changes.
     /// </summary>
     public ICommand? SelectedObjectChangedCommand
     {
         get => (ICommand?)GetValue(SelectedObjectChangedCommandProperty);
         set => SetValue(SelectedObjectChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectedObjectChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectedObjectChangedCommandParameter
+    {
+        get => GetValue(SelectedObjectChangedCommandParameterProperty);
+        set => SetValue(SelectedObjectChangedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -284,11 +352,31 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         set => SetValue(PropertySelectionChangedCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="PropertySelectionChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? PropertySelectionChangedCommandParameter
+    {
+        get => GetValue(PropertySelectionChangedCommandParameterProperty);
+        set => SetValue(PropertySelectionChangedCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? GotFocusCommand
     {
         get => (ICommand?)GetValue(GotFocusCommandProperty);
         set => SetValue(GotFocusCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="GotFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? GotFocusCommandParameter
+    {
+        get => GetValue(GotFocusCommandParameterProperty);
+        set => SetValue(GotFocusCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -298,11 +386,31 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         set => SetValue(LostFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LostFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LostFocusCommandParameter
+    {
+        get => GetValue(LostFocusCommandParameterProperty);
+        set => SetValue(LostFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? KeyPressCommand
     {
         get => (ICommand?)GetValue(KeyPressCommandProperty);
         set => SetValue(KeyPressCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="KeyPressCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? KeyPressCommandParameter
+    {
+        get => GetValue(KeyPressCommandParameterProperty);
+        set => SetValue(KeyPressCommandParameterProperty, value);
     }
 
     #endregion
@@ -374,7 +482,7 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
 
         if (KeyPressCommand?.CanExecute(e) == true)
         {
-            KeyPressCommand.Execute(e);
+            KeyPressCommand.Execute(KeyPressCommandParameter ?? e);
             if (e.Handled) return true;
         }
 
@@ -442,7 +550,7 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         _hasKeyboardFocus = true;
         OnPropertyChanged(nameof(HasKeyboardFocus));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
         return true;
     }
 
@@ -973,7 +1081,7 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
 
         var args = new PropertySelectionChangedEventArgs(oldProperty, property);
         PropertySelectionChanged?.Invoke(this, args);
-        PropertySelectionChangedCommand?.Execute(args);
+        PropertySelectionChangedCommand?.Execute(PropertySelectionChangedCommandParameter ?? args);
     }
 
     private void SelectNextProperty()
@@ -1001,7 +1109,7 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
     private void OnPropertyValueChanged(object? sender, PropertyValueChangedEventArgs e)
     {
         PropertyValueChanged?.Invoke(this, e);
-        PropertyChangedCommand?.Execute(e);
+        PropertyChangedCommand?.Execute(PropertyChangedCommandParameter ?? e);
     }
 
     private void OnSearchTextChanged(object? sender, TextChangedEventArgs e)
@@ -1025,7 +1133,7 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         {
             var args = new SelectedObjectChangedEventArgs(oldValue, newValue);
             grid.SelectedObjectChanged?.Invoke(grid, args);
-            grid.SelectedObjectChangedCommand?.Execute(args);
+            grid.SelectedObjectChangedCommand?.Execute(grid.SelectedObjectChangedCommandParameter ?? args);
             grid.DiscoverProperties();
         }
     }

--- a/src/MauiControlsExtras/Controls/RichTextEditor/RichTextEditor.xaml.cs
+++ b/src/MauiControlsExtras/Controls/RichTextEditor/RichTextEditor.xaml.cs
@@ -221,11 +221,27 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         typeof(RichTextEditor));
 
     /// <summary>
+    /// Identifies the <see cref="ContentChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ContentChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(ContentChangedCommandParameter),
+        typeof(object),
+        typeof(RichTextEditor));
+
+    /// <summary>
     /// Identifies the <see cref="SelectionChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectionChangedCommandProperty = BindableProperty.Create(
         nameof(SelectionChangedCommand),
         typeof(ICommand),
+        typeof(RichTextEditor));
+
+    /// <summary>
+    /// Identifies the <see cref="SelectionChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty SelectionChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(SelectionChangedCommandParameter),
+        typeof(object),
         typeof(RichTextEditor));
 
     /// <summary>
@@ -237,11 +253,27 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         typeof(RichTextEditor));
 
     /// <summary>
+    /// Identifies the <see cref="LinkTappedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LinkTappedCommandParameterProperty = BindableProperty.Create(
+        nameof(LinkTappedCommandParameter),
+        typeof(object),
+        typeof(RichTextEditor));
+
+    /// <summary>
     /// Identifies the <see cref="FocusChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty FocusChangedCommandProperty = BindableProperty.Create(
         nameof(FocusChangedCommand),
         typeof(ICommand),
+        typeof(RichTextEditor));
+
+    /// <summary>
+    /// Identifies the <see cref="FocusChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty FocusChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(FocusChangedCommandParameter),
+        typeof(object),
         typeof(RichTextEditor));
 
     /// <summary>
@@ -253,11 +285,27 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         typeof(RichTextEditor));
 
     /// <summary>
+    /// Identifies the <see cref="CopyCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CopyCommandParameterProperty = BindableProperty.Create(
+        nameof(CopyCommandParameter),
+        typeof(object),
+        typeof(RichTextEditor));
+
+    /// <summary>
     /// Identifies the <see cref="CutCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty CutCommandProperty = BindableProperty.Create(
         nameof(CutCommand),
         typeof(ICommand),
+        typeof(RichTextEditor));
+
+    /// <summary>
+    /// Identifies the <see cref="CutCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CutCommandParameterProperty = BindableProperty.Create(
+        nameof(CutCommandParameter),
+        typeof(object),
         typeof(RichTextEditor));
 
     /// <summary>
@@ -269,11 +317,27 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         typeof(RichTextEditor));
 
     /// <summary>
+    /// Identifies the <see cref="PasteCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PasteCommandParameterProperty = BindableProperty.Create(
+        nameof(PasteCommandParameter),
+        typeof(object),
+        typeof(RichTextEditor));
+
+    /// <summary>
     /// Identifies the <see cref="UndoCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty UndoCommandProperty = BindableProperty.Create(
         nameof(UndoCommand),
         typeof(ICommand),
+        typeof(RichTextEditor));
+
+    /// <summary>
+    /// Identifies the <see cref="UndoCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty UndoCommandParameterProperty = BindableProperty.Create(
+        nameof(UndoCommandParameter),
+        typeof(object),
         typeof(RichTextEditor));
 
     /// <summary>
@@ -285,11 +349,27 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         typeof(RichTextEditor));
 
     /// <summary>
+    /// Identifies the <see cref="RedoCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty RedoCommandParameterProperty = BindableProperty.Create(
+        nameof(RedoCommandParameter),
+        typeof(object),
+        typeof(RichTextEditor));
+
+    /// <summary>
     /// Identifies the <see cref="GotFocusCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty GotFocusCommandProperty = BindableProperty.Create(
         nameof(GotFocusCommand),
         typeof(ICommand),
+        typeof(RichTextEditor));
+
+    /// <summary>
+    /// Identifies the <see cref="GotFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(GotFocusCommandParameter),
+        typeof(object),
         typeof(RichTextEditor));
 
     /// <summary>
@@ -301,11 +381,27 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         typeof(RichTextEditor));
 
     /// <summary>
+    /// Identifies the <see cref="LostFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(LostFocusCommandParameter),
+        typeof(object),
+        typeof(RichTextEditor));
+
+    /// <summary>
     /// Identifies the <see cref="KeyPressCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty KeyPressCommandProperty = BindableProperty.Create(
         nameof(KeyPressCommand),
         typeof(ICommand),
+        typeof(RichTextEditor));
+
+    /// <summary>
+    /// Identifies the <see cref="KeyPressCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandParameterProperty = BindableProperty.Create(
+        nameof(KeyPressCommandParameter),
+        typeof(object),
         typeof(RichTextEditor));
 
     #endregion
@@ -502,12 +598,32 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ContentChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ContentChangedCommandParameter
+    {
+        get => GetValue(ContentChangedCommandParameterProperty);
+        set => SetValue(ContentChangedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when selection changes.
     /// </summary>
     public ICommand? SelectionChangedCommand
     {
         get => (ICommand?)GetValue(SelectionChangedCommandProperty);
         set => SetValue(SelectionChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="SelectionChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? SelectionChangedCommandParameter
+    {
+        get => GetValue(SelectionChangedCommandParameterProperty);
+        set => SetValue(SelectionChangedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -520,12 +636,32 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LinkTappedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LinkTappedCommandParameter
+    {
+        get => GetValue(LinkTappedCommandParameterProperty);
+        set => SetValue(LinkTappedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when focus changes.
     /// </summary>
     public ICommand? FocusChangedCommand
     {
         get => (ICommand?)GetValue(FocusChangedCommandProperty);
         set => SetValue(FocusChangedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="FocusChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? FocusChangedCommandParameter
+    {
+        get => GetValue(FocusChangedCommandParameterProperty);
+        set => SetValue(FocusChangedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -538,12 +674,32 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CopyCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CopyCommandParameter
+    {
+        get => GetValue(CopyCommandParameterProperty);
+        set => SetValue(CopyCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the cut command.
     /// </summary>
     public ICommand? CutCommand
     {
         get => (ICommand?)GetValue(CutCommandProperty);
         set => SetValue(CutCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CutCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CutCommandParameter
+    {
+        get => GetValue(CutCommandParameterProperty);
+        set => SetValue(CutCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -556,12 +712,32 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="PasteCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? PasteCommandParameter
+    {
+        get => GetValue(PasteCommandParameterProperty);
+        set => SetValue(PasteCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the undo command.
     /// </summary>
     public ICommand? UndoCommand
     {
         get => (ICommand?)GetValue(UndoCommandProperty);
         set => SetValue(UndoCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="UndoCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? UndoCommandParameter
+    {
+        get => GetValue(UndoCommandParameterProperty);
+        set => SetValue(UndoCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -573,11 +749,31 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         set => SetValue(RedoCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="RedoCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? RedoCommandParameter
+    {
+        get => GetValue(RedoCommandParameterProperty);
+        set => SetValue(RedoCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? GotFocusCommand
     {
         get => (ICommand?)GetValue(GotFocusCommandProperty);
         set => SetValue(GotFocusCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="GotFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? GotFocusCommandParameter
+    {
+        get => GetValue(GotFocusCommandParameterProperty);
+        set => SetValue(GotFocusCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -587,11 +783,31 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         set => SetValue(LostFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LostFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LostFocusCommandParameter
+    {
+        get => GetValue(LostFocusCommandParameterProperty);
+        set => SetValue(LostFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? KeyPressCommand
     {
         get => (ICommand?)GetValue(KeyPressCommandProperty);
         set => SetValue(KeyPressCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="KeyPressCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? KeyPressCommandParameter
+    {
+        get => GetValue(KeyPressCommandParameterProperty);
+        set => SetValue(KeyPressCommandParameterProperty, value);
     }
 
     #endregion
@@ -666,7 +882,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
         // Execute KeyPressCommand
         if (KeyPressCommand?.CanExecute(e) == true)
         {
-            KeyPressCommand.Execute(e);
+            KeyPressCommand.Execute(KeyPressCommandParameter ?? e);
             if (e.Handled) return true;
         }
 
@@ -750,7 +966,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     public void Copy()
     {
         _ = ExecuteJavaScriptAsync("document.execCommand('copy')");
-        CopyCommand?.Execute(null);
+        CopyCommand?.Execute(CopyCommandParameter);
     }
 
     /// <inheritdoc/>
@@ -758,7 +974,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     {
         if (IsReadOnly) return;
         _ = ExecuteJavaScriptAsync("document.execCommand('cut')");
-        CutCommand?.Execute(null);
+        CutCommand?.Execute(CutCommandParameter);
     }
 
     /// <inheritdoc/>
@@ -766,7 +982,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     {
         if (IsReadOnly) return;
         _ = ExecuteJavaScriptAsync("document.execCommand('paste')");
-        PasteCommand?.Execute(null);
+        PasteCommand?.Execute(PasteCommandParameter);
     }
 
     /// <inheritdoc/>
@@ -796,7 +1012,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     {
         if (!CanUndo || IsReadOnly) return false;
         _ = ExecuteJavaScriptAsync("quill.history.undo()");
-        UndoCommand?.Execute(null);
+        UndoCommand?.Execute(UndoCommandParameter);
         return true;
     }
 
@@ -805,7 +1021,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     {
         if (!CanRedo || IsReadOnly) return false;
         _ = ExecuteJavaScriptAsync("quill.history.redo()");
-        RedoCommand?.Execute(null);
+        RedoCommand?.Execute(RedoCommandParameter);
         return true;
     }
 
@@ -1307,7 +1523,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
             e.Cancel = true;
             var args = new RichTextLinkTappedEventArgs(e.Url, null);
             LinkTapped?.Invoke(this, args);
-            LinkTappedCommand?.Execute(args);
+            LinkTappedCommand?.Execute(LinkTappedCommandParameter ?? args);
 
             if (!args.Handled)
             {
@@ -1335,7 +1551,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
 
                     var args = new RichTextContentChangedEventArgs(oldContent, html, ContentFormat.Html);
                     ContentChanged?.Invoke(this, args);
-                    ContentChangedCommand?.Execute(args);
+                    ContentChangedCommand?.Execute(ContentChangedCommandParameter ?? args);
 
                     // Update undo/redo state
                     _ = UpdateUndoRedoStateAsync();
@@ -1348,7 +1564,7 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
                 var text = Uri.UnescapeDataString(query["text"] ?? "");
                 var selArgs = new RichTextSelectionChangedEventArgs(start, length, text);
                 SelectionChanged?.Invoke(this, selArgs);
-                SelectionChangedCommand?.Execute(selArgs);
+                SelectionChangedCommand?.Execute(SelectionChangedCommandParameter ?? selArgs);
                 break;
 
             case "focus-changed":
@@ -1365,17 +1581,17 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
                     if (focused)
                     {
                         KeyboardFocusGained?.Invoke(this, focusEventArgs);
-                        GotFocusCommand?.Execute(this);
+                        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
                     }
                     else
                     {
                         KeyboardFocusLost?.Invoke(this, focusEventArgs);
-                        LostFocusCommand?.Execute(this);
+                        LostFocusCommand?.Execute(LostFocusCommandParameter ?? this);
                     }
 
                     var focusArgs = new RichTextFocusChangedEventArgs(focused);
                     FocusChanged?.Invoke(this, focusArgs);
-                    FocusChangedCommand?.Execute(focusArgs);
+                    FocusChangedCommand?.Execute(FocusChangedCommandParameter ?? focusArgs);
                 }
                 break;
         }

--- a/src/MauiControlsExtras/Controls/Wizard/Wizard.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Wizard/Wizard.xaml.cs
@@ -233,11 +233,27 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         typeof(Wizard));
 
     /// <summary>
+    /// Identifies the <see cref="StepChangedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty StepChangedCommandParameterProperty = BindableProperty.Create(
+        nameof(StepChangedCommandParameter),
+        typeof(object),
+        typeof(Wizard));
+
+    /// <summary>
     /// Identifies the <see cref="StepValidatingCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty StepValidatingCommandProperty = BindableProperty.Create(
         nameof(StepValidatingCommand),
         typeof(ICommand),
+        typeof(Wizard));
+
+    /// <summary>
+    /// Identifies the <see cref="StepValidatingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty StepValidatingCommandParameterProperty = BindableProperty.Create(
+        nameof(StepValidatingCommandParameter),
+        typeof(object),
         typeof(Wizard));
 
     /// <summary>
@@ -249,11 +265,27 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         typeof(Wizard));
 
     /// <summary>
+    /// Identifies the <see cref="FinishedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty FinishedCommandParameterProperty = BindableProperty.Create(
+        nameof(FinishedCommandParameter),
+        typeof(object),
+        typeof(Wizard));
+
+    /// <summary>
     /// Identifies the <see cref="CancelledCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty CancelledCommandProperty = BindableProperty.Create(
         nameof(CancelledCommand),
         typeof(ICommand),
+        typeof(Wizard));
+
+    /// <summary>
+    /// Identifies the <see cref="CancelledCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CancelledCommandParameterProperty = BindableProperty.Create(
+        nameof(CancelledCommandParameter),
+        typeof(object),
         typeof(Wizard));
 
     /// <summary>
@@ -265,6 +297,14 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         typeof(Wizard));
 
     /// <summary>
+    /// Identifies the <see cref="GotFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty GotFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(GotFocusCommandParameter),
+        typeof(object),
+        typeof(Wizard));
+
+    /// <summary>
     /// Identifies the <see cref="LostFocusCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty LostFocusCommandProperty = BindableProperty.Create(
@@ -273,11 +313,27 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         typeof(Wizard));
 
     /// <summary>
+    /// Identifies the <see cref="LostFocusCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty LostFocusCommandParameterProperty = BindableProperty.Create(
+        nameof(LostFocusCommandParameter),
+        typeof(object),
+        typeof(Wizard));
+
+    /// <summary>
     /// Identifies the <see cref="KeyPressCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty KeyPressCommandProperty = BindableProperty.Create(
         nameof(KeyPressCommand),
         typeof(ICommand),
+        typeof(Wizard));
+
+    /// <summary>
+    /// Identifies the <see cref="KeyPressCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty KeyPressCommandParameterProperty = BindableProperty.Create(
+        nameof(KeyPressCommandParameter),
+        typeof(object),
         typeof(Wizard));
 
     #endregion
@@ -530,6 +586,16 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="StepChangedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? StepChangedCommandParameter
+    {
+        get => GetValue(StepChangedCommandParameterProperty);
+        set => SetValue(StepChangedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the cancelable command executed before step validation.
     /// The command parameter is <see cref="WizardStepValidatingEventArgs"/>.
     /// Set Cancel = true to prevent navigation.
@@ -538,6 +604,16 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
     {
         get => (ICommand?)GetValue(StepValidatingCommandProperty);
         set => SetValue(StepValidatingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="StepValidatingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? StepValidatingCommandParameter
+    {
+        get => GetValue(StepValidatingCommandParameterProperty);
+        set => SetValue(StepValidatingCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -550,12 +626,32 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="FinishedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? FinishedCommandParameter
+    {
+        get => GetValue(FinishedCommandParameterProperty);
+        set => SetValue(FinishedCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when the wizard is cancelled.
     /// </summary>
     public ICommand? CancelledCommand
     {
         get => (ICommand?)GetValue(CancelledCommandProperty);
         set => SetValue(CancelledCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CancelledCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CancelledCommandParameter
+    {
+        get => GetValue(CancelledCommandParameterProperty);
+        set => SetValue(CancelledCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -565,6 +661,16 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         set => SetValue(GotFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="GotFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? GotFocusCommandParameter
+    {
+        get => GetValue(GotFocusCommandParameterProperty);
+        set => SetValue(GotFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? LostFocusCommand
     {
@@ -572,11 +678,31 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         set => SetValue(LostFocusCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="LostFocusCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? LostFocusCommandParameter
+    {
+        get => GetValue(LostFocusCommandParameterProperty);
+        set => SetValue(LostFocusCommandParameterProperty, value);
+    }
+
     /// <inheritdoc/>
     public ICommand? KeyPressCommand
     {
         get => (ICommand?)GetValue(KeyPressCommandProperty);
         set => SetValue(KeyPressCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="KeyPressCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? KeyPressCommandParameter
+    {
+        get => GetValue(KeyPressCommandParameterProperty);
+        set => SetValue(KeyPressCommandParameterProperty, value);
     }
 
     #endregion
@@ -659,7 +785,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
 
         if (KeyPressCommand?.CanExecute(e) == true)
         {
-            KeyPressCommand.Execute(e);
+            KeyPressCommand.Execute(KeyPressCommandParameter ?? e);
             if (e.Handled) return true;
         }
 
@@ -736,7 +862,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         _hasKeyboardFocus = true;
         OnPropertyChanged(nameof(HasKeyboardFocus));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
         return true;
     }
 
@@ -1027,7 +1153,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
 
         if (StepValidatingCommand?.CanExecute(validatingArgs) == true)
         {
-            StepValidatingCommand.Execute(validatingArgs);
+            StepValidatingCommand.Execute(StepValidatingCommandParameter ?? validatingArgs);
         }
 
         if (validatingArgs.Cancel)
@@ -1066,7 +1192,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         // Raise changed event
         var changedArgs = new WizardStepChangedEventArgs(oldStep, newStep, oldIndex, index);
         StepChanged?.Invoke(this, changedArgs);
-        StepChangedCommand?.Execute(changedArgs);
+        StepChangedCommand?.Execute(StepChangedCommandParameter ?? changedArgs);
 
         return true;
     }
@@ -1105,7 +1231,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         // Raise finished event
         var finishedArgs = new WizardFinishedEventArgs(false, _steps.ToList());
         Finished?.Invoke(this, finishedArgs);
-        FinishedCommand?.Execute(finishedArgs);
+        FinishedCommand?.Execute(FinishedCommandParameter ?? finishedArgs);
 
         return true;
     }
@@ -1125,7 +1251,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         // Raise cancelled event
         var cancelledArgs = new WizardFinishedEventArgs(true, _steps.ToList());
         Cancelled?.Invoke(this, cancelledArgs);
-        CancelledCommand?.Execute(cancelledArgs);
+        CancelledCommand?.Execute(CancelledCommandParameter ?? cancelledArgs);
 
         return true;
     }
@@ -1454,7 +1580,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         OnPropertyChanged(nameof(HasKeyboardFocus));
         OnPropertyChanged(nameof(CurrentBorderColor));
         KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
-        GotFocusCommand?.Execute(this);
+        GotFocusCommand?.Execute(GotFocusCommandParameter ?? this);
     }
 
     private void OnControlUnfocused(object? sender, FocusEventArgs e)
@@ -1463,7 +1589,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         OnPropertyChanged(nameof(HasKeyboardFocus));
         OnPropertyChanged(nameof(CurrentBorderColor));
         KeyboardFocusLost?.Invoke(this, new KeyboardFocusEventArgs(false));
-        LostFocusCommand?.Execute(this);
+        LostFocusCommand?.Execute(LostFocusCommandParameter ?? this);
     }
 
     private void OnStepsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/MauiControlsExtras/Controls/Wizard/WizardStep.cs
+++ b/src/MauiControlsExtras/Controls/Wizard/WizardStep.cs
@@ -82,6 +82,14 @@ public class WizardStep : ContentView, INotifyPropertyChanged
         null);
 
     /// <summary>
+    /// Identifies the <see cref="ValidationCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ValidationCommandParameterProperty = BindableProperty.Create(
+        nameof(ValidationCommandParameter),
+        typeof(object),
+        typeof(WizardStep));
+
+    /// <summary>
     /// Identifies the <see cref="OnEnterCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty OnEnterCommandProperty = BindableProperty.Create(
@@ -91,6 +99,14 @@ public class WizardStep : ContentView, INotifyPropertyChanged
         null);
 
     /// <summary>
+    /// Identifies the <see cref="OnEnterCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty OnEnterCommandParameterProperty = BindableProperty.Create(
+        nameof(OnEnterCommandParameter),
+        typeof(object),
+        typeof(WizardStep));
+
+    /// <summary>
     /// Identifies the <see cref="OnExitCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty OnExitCommandProperty = BindableProperty.Create(
@@ -98,6 +114,14 @@ public class WizardStep : ContentView, INotifyPropertyChanged
         typeof(ICommand),
         typeof(WizardStep),
         null);
+
+    /// <summary>
+    /// Identifies the <see cref="OnExitCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty OnExitCommandParameterProperty = BindableProperty.Create(
+        nameof(OnExitCommandParameter),
+        typeof(object),
+        typeof(WizardStep));
 
     #endregion
 
@@ -168,6 +192,16 @@ public class WizardStep : ContentView, INotifyPropertyChanged
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ValidationCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ValidationCommandParameter
+    {
+        get => GetValue(ValidationCommandParameterProperty);
+        set => SetValue(ValidationCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets a command executed when entering this step.
     /// </summary>
     public ICommand? OnEnterCommand
@@ -177,12 +211,32 @@ public class WizardStep : ContentView, INotifyPropertyChanged
     }
 
     /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="OnEnterCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? OnEnterCommandParameter
+    {
+        get => GetValue(OnEnterCommandParameterProperty);
+        set => SetValue(OnEnterCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets a command executed when leaving this step.
     /// </summary>
     public ICommand? OnExitCommand
     {
         get => (ICommand?)GetValue(OnExitCommandProperty);
         set => SetValue(OnExitCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="OnExitCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? OnExitCommandParameter
+    {
+        get => GetValue(OnExitCommandParameterProperty);
+        set => SetValue(OnExitCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -283,9 +337,10 @@ public class WizardStep : ContentView, INotifyPropertyChanged
 
         if (ValidationCommand != null)
         {
-            if (ValidationCommand.CanExecute(this))
+            var parameter = ValidationCommandParameter ?? this;
+            if (ValidationCommand.CanExecute(parameter))
             {
-                ValidationCommand.Execute(this);
+                ValidationCommand.Execute(parameter);
             }
         }
 
@@ -303,7 +358,7 @@ public class WizardStep : ContentView, INotifyPropertyChanged
     internal void OnEnter()
     {
         Status = WizardStepStatus.Current;
-        OnEnterCommand?.Execute(this);
+        OnEnterCommand?.Execute(OnEnterCommandParameter ?? this);
         Entered?.Invoke(this, EventArgs.Empty);
     }
 
@@ -317,7 +372,7 @@ public class WizardStep : ContentView, INotifyPropertyChanged
         {
             Status = WizardStepStatus.Completed;
         }
-        OnExitCommand?.Execute(this);
+        OnExitCommand?.Execute(OnExitCommandParameter ?? this);
         Exited?.Invoke(this, EventArgs.Empty);
     }
 


### PR DESCRIPTION
## Summary

Adds the missing `{Action}CommandParameter` bindable properties alongside every `{Action}Command` that was missing one, following the ARCHITECTURE.md convention. Command invocations now use `CommandParameter ?? defaultValue` so the default behavior is preserved while consumers can override the parameter via XAML binding.

## What changed

- **DataGridView** — 26 CommandParameter properties added (SelectionChanged, CellTapped, CellDoubleTapped, Sorting, Sorted, CellEditStarted, CellEditEnded, CellEditCancelled, RowEditEnded, Filtering, Filtered, PageChanged, Export, Undo, Redo, Copy, Cut, Paste, ColumnReordered, RowSelected, RowDeselected, SelectAll, ClearSelection, GotFocus, LostFocus, KeyPress)
- **Accordion** — 8 CommandParameter properties (ItemExpanded, ItemCollapsed, GotFocus, LostFocus, KeyPress, SelectAll, ClearSelection, SelectionChanged)
- **AccordionItem** — 2 CommandParameter properties (Expand, Collapse)
- **Calendar** — 8 CommandParameter properties (DateSelected, DisplayDateChanged, GotFocus, LostFocus, KeyPress, SelectAll, ClearSelection, SelectionChanged)
- **Breadcrumb** — 8 CommandParameter properties (ItemClicked, HomeClicked, GotFocus, LostFocus, KeyPress, SelectAll, ClearSelection, SelectionChanged) — NavigatingCommandParameter already existed
- **Wizard** — 7 CommandParameter properties (StepChanged, StepValidating, Finished, Cancelled, GotFocus, LostFocus, KeyPress)
- **WizardStep** — 3 CommandParameter properties (Validation, OnEnter, OnExit)
- **BindingNavigator** — 9 CommandParameter properties (PositionChanged, Add, Delete, Save, Cancel, Refresh, GotFocus, LostFocus, KeyPress)
- **PropertyGrid** — 6 CommandParameter properties (PropertyChanged, SelectedObjectChanged, PropertySelectionChanged, GotFocus, LostFocus, KeyPress)
- **RichTextEditor** — 12 CommandParameter properties (ContentChanged, SelectionChanged, LinkTapped, FocusChanged, Copy, Cut, Paste, Undo, Redo, GotFocus, LostFocus, KeyPress)

**Total: 89 CommandParameter properties added**

Each follows the established pattern:
1. `BindableProperty` declaration interleaved after the corresponding Command declaration
2. `object? {Action}CommandParameter` CLR property interleaved after the Command CLR property
3. Command invocations updated to `CommandParameter ?? existingDefaultValue`

## Validation performed

```
dotnet build src/MauiControlsExtras/MauiControlsExtras.csproj
  Build succeeded. 0 Warning(s), 0 Error(s)

dotnet test tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj
  Passed! Failed: 0, Passed: 14, Skipped: 0, Total: 14

dotnet build samples/DemoApp/DemoApp.csproj
  Build succeeded. 0 Warning(s), 0 Error(s)
```

## Manual verification checklist

- [ ] Existing demo app bindings still work (no CommandParameter is set so default args flow through)
- [ ] Setting a CommandParameter on any command overrides the default argument

Closes #161