### PR TITLE
Fix #172: increase touch targets to meet 44dp minimum

### DIFF
--- a/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml.cs
@@ -1087,9 +1087,11 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         var startDay = GetFirstDayOfWeekValue();
         var culture = CultureInfo.CurrentCulture;
 
+        var effectiveCellSize = Math.Max(CellSize, 48);
+
         if (ShowWeekNumbers)
         {
-            dayOfWeekHeader.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(CellSize)));
+            dayOfWeekHeader.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(effectiveCellSize)));
             dayOfWeekHeader.Children.Add(new Label
             {
                 Text = "Wk",
@@ -1101,7 +1103,7 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
 
         for (int i = 0; i < 7; i++)
         {
-            dayOfWeekHeader.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(CellSize)));
+            dayOfWeekHeader.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(effectiveCellSize)));
             var dayIndex = (startDay + i) % 7;
             var dayName = culture.DateTimeFormat.AbbreviatedDayNames[dayIndex];
 
@@ -1122,19 +1124,19 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
 
         for (int r = 0; r < 6; r++)
         {
-            calendarGrid.RowDefinitions.Add(new RowDefinition(new GridLength(CellSize)));
+            calendarGrid.RowDefinitions.Add(new RowDefinition(new GridLength(effectiveCellSize)));
         }
 
         var colOffset = 0;
         if (ShowWeekNumbers)
         {
-            calendarGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(CellSize)));
+            calendarGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(effectiveCellSize)));
             colOffset = 1;
         }
 
         for (int c = 0; c < 7; c++)
         {
-            calendarGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(CellSize)));
+            calendarGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(effectiveCellSize)));
         }
 
         var firstOfMonth = new DateTime(_displayDate.Year, _displayDate.Month, 1);
@@ -1188,10 +1190,13 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         var isEnabled = IsDateEnabled(date);
         var isFocused = _hasKeyboardFocus && row == _focusedRow && col == _focusedCol;
 
+        var cellDim = CellSize - 4;
         var container = new Border
         {
-            WidthRequest = CellSize - 4,
-            HeightRequest = CellSize - 4,
+            WidthRequest = cellDim,
+            HeightRequest = cellDim,
+            MinimumWidthRequest = 44,
+            MinimumHeightRequest = 44,
             StrokeThickness = isFocused ? 2 : (isToday ? 1 : 0),
             Stroke = isFocused ? new SolidColorBrush(EffectiveAccentColor) :
                      (isToday ? new SolidColorBrush(EffectiveTodayHighlightColor) : null),

--- a/src/MauiControlsExtras/Controls/TokenEntry.xaml.cs
+++ b/src/MauiControlsExtras/Controls/TokenEntry.xaml.cs
@@ -685,13 +685,24 @@ public partial class TokenEntry : TextStyledControlBase, IValidatable, Base.IKey
             Text = "✕",
             FontSize = 11,
             TextColor = accentColor.WithAlpha(0.7f),
-            VerticalOptions = LayoutOptions.Center
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Center
+        };
+        var removeContainer = new Border
+        {
+            BackgroundColor = Colors.Transparent,
+            StrokeThickness = 0,
+            MinimumWidthRequest = 44,
+            MinimumHeightRequest = 44,
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center,
+            Content = removeLabel
         };
         var removeTap = new TapGestureRecognizer();
         removeTap.Tapped += (s, e) => RemoveToken(token);
-        removeLabel.GestureRecognizers.Add(removeTap);
-        Grid.SetColumn(removeLabel, 1);
-        chipGrid.Add(removeLabel);
+        removeContainer.GestureRecognizers.Add(removeTap);
+        Grid.SetColumn(removeContainer, 1);
+        chipGrid.Add(removeContainer);
 
         chipBorder.Content = chipGrid;
 

--- a/src/MauiControlsExtras/Controls/TreeView.xaml
+++ b/src/MauiControlsExtras/Controls/TreeView.xaml
@@ -43,8 +43,8 @@
 
                             <!-- Expand/Collapse Button -->
                             <Border Grid.Column="1"
-                                    WidthRequest="24"
-                                    HeightRequest="24"
+                                    MinimumWidthRequest="44"
+                                    MinimumHeightRequest="44"
                                     BackgroundColor="Transparent"
                                     StrokeThickness="0"
                                     IsVisible="{Binding HasChildren}">
@@ -60,15 +60,15 @@
 
                             <!-- Placeholder for items without children (alignment) -->
                             <BoxView Grid.Column="1"
-                                     WidthRequest="24"
-                                     HeightRequest="24"
+                                     MinimumWidthRequest="44"
+                                     MinimumHeightRequest="44"
                                      Color="Transparent"
                                      IsVisible="{Binding HasNoChildren}" />
 
                             <!-- Checkbox (optional) -->
                             <Border Grid.Column="2"
-                                    WidthRequest="24"
-                                    HeightRequest="24"
+                                    MinimumWidthRequest="44"
+                                    MinimumHeightRequest="44"
                                     BackgroundColor="Transparent"
                                     StrokeThickness="0"
                                     IsVisible="{Binding ShowCheckBoxes, Source={x:Reference thisControl}}"


### PR DESCRIPTION
## Summary
- **TokenEntry**: Wrap remove button (✕) in a transparent Border with 44×44dp minimum, move tap gesture to the container
- **TreeView**: Change expander and checkbox borders from fixed 24×24 to 44×44dp minimums (includes alignment placeholder)
- **Calendar**: Add 44×44dp minimum on day cell borders; guard grid row/column definitions with `Math.Max(CellSize, 48)`

Closes #172

## Test plan
- [x] `dotnet build` — library compiles (0 errors, 0 warnings)
- [x] `dotnet test` — 14/14 tests pass
- [x] `dotnet build samples/DemoApp` — demo app compiles
- [ ] Manual: verify TokenEntry remove button is easily tappable on mobile
- [ ] Manual: verify TreeView expander/checkbox icons are easily tappable on mobile
- [ ] Manual: verify Calendar day cells are easily tappable on mobile