### PR TITLE
feat(MouseWheel): add mouse wheel support for NumericUpDown, Rating, RangeSlider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **NumericUpDown**: Mouse wheel support to increment/decrement value when focused (#168)
+- **Rating**: Mouse wheel support to adjust rating when focused (#168)
+- **RangeSlider**: Mouse wheel support to adjust active thumb when focused (#168)
+
 ### Fixed
 
 - **Keyboard**: Arrow key names now use `"Arrow*"` convention consistently across all controls (#174)


### PR DESCRIPTION
## Summary
- Add platform-specific mouse wheel handlers (Windows `PointerWheelChanged`, macOS Catalyst `UIPanGestureRecognizer`) to NumericUpDown, Rating, and RangeSlider
- All handlers are focus-gated and mark events as handled to prevent bubbling to parent scroll containers
- DataGridView and ComboBox already receive mouse wheel natively via ScrollView/CollectionView — no changes needed

Closes #168

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 14/14 passing
- [ ] Manual: Focus NumericUpDown → scroll wheel → value increments/decrements by Step
- [ ] Manual: Focus Rating → scroll wheel → rating changes by 1 (or 0.5 if Half precision)
- [ ] Manual: Focus RangeSlider → scroll wheel → active thumb moves by Step
- [ ] Manual: DataGridView → scroll wheel → scrolls vertically (native)
- [ ] Manual: ComboBox dropdown open → scroll wheel → scrolls items (native)