### PR TITLE
feat(Tests): add per-control command execution and event raising tests

### DIFF
--- a/tests/MauiControlsExtras.Tests/Controls/AccordionItemTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/AccordionItemTests.cs
@@ -1,0 +1,192 @@
+using MauiControlsExtras.Controls;
+using MauiControlsExtras.Tests.Helpers;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class AccordionItemTests
+{
+    [Fact]
+    public void Expand_WhenCollapsed_SetsIsExpandedTrue()
+    {
+        var item = new AccordionItem();
+
+        item.Expand();
+
+        Assert.True(item.IsExpanded);
+    }
+
+    [Fact]
+    public void Expand_WhenAlreadyExpanded_DoesNothing()
+    {
+        var item = new AccordionItem { IsExpanded = true };
+        var cmd = new TestCommand();
+        item.ExpandCommand = cmd;
+
+        item.Expand();
+
+        Assert.False(cmd.WasExecuted);
+    }
+
+    [Fact]
+    public void Expand_WhenDisabled_DoesNotExpand()
+    {
+        var item = new AccordionItem { IsEnabled = false };
+
+        item.Expand();
+
+        Assert.False(item.IsExpanded);
+    }
+
+    [Fact]
+    public void Expand_ExecutesExpandCommand()
+    {
+        var item = new AccordionItem();
+        var cmd = new TestCommand();
+        item.ExpandCommand = cmd;
+
+        item.Expand();
+
+        Assert.True(cmd.WasExecuted);
+        Assert.Equal(1, cmd.ExecuteCount);
+    }
+
+    [Fact]
+    public void Expand_UsesExpandCommandParameter_WhenSet()
+    {
+        var item = new AccordionItem();
+        var cmd = new TestCommand();
+        item.ExpandCommand = cmd;
+        item.ExpandCommandParameter = "custom-param";
+
+        item.Expand();
+
+        Assert.Equal("custom-param", cmd.LastParameter);
+    }
+
+    [Fact]
+    public void Expand_PassesSelfAsParameter_WhenNoParameterSet()
+    {
+        var item = new AccordionItem();
+        var cmd = new TestCommand();
+        item.ExpandCommand = cmd;
+
+        item.Expand();
+
+        Assert.Same(item, cmd.LastParameter);
+    }
+
+    [Fact]
+    public void Expand_RaisesExpandedEvent()
+    {
+        var item = new AccordionItem();
+        var raised = false;
+        item.Expanded += (_, _) => raised = true;
+
+        item.Expand();
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Collapse_WhenExpanded_SetsIsExpandedFalse()
+    {
+        var item = new AccordionItem { IsExpanded = true };
+
+        item.Collapse();
+
+        Assert.False(item.IsExpanded);
+    }
+
+    [Fact]
+    public void Collapse_WhenAlreadyCollapsed_DoesNothing()
+    {
+        var item = new AccordionItem();
+        var cmd = new TestCommand();
+        item.CollapseCommand = cmd;
+
+        item.Collapse();
+
+        Assert.False(cmd.WasExecuted);
+    }
+
+    [Fact]
+    public void Collapse_ExecutesCollapseCommand()
+    {
+        var item = new AccordionItem { IsExpanded = true };
+        var cmd = new TestCommand();
+        item.CollapseCommand = cmd;
+
+        item.Collapse();
+
+        Assert.True(cmd.WasExecuted);
+    }
+
+    [Fact]
+    public void Collapse_UsesCollapseCommandParameter_WhenSet()
+    {
+        var item = new AccordionItem { IsExpanded = true };
+        var cmd = new TestCommand();
+        item.CollapseCommand = cmd;
+        item.CollapseCommandParameter = 42;
+
+        item.Collapse();
+
+        Assert.Equal(42, cmd.LastParameter);
+    }
+
+    [Fact]
+    public void Collapse_RaisesCollapsedEvent()
+    {
+        var item = new AccordionItem { IsExpanded = true };
+        var raised = false;
+        item.Collapsed += (_, _) => raised = true;
+
+        item.Collapse();
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Toggle_FromCollapsed_Expands()
+    {
+        var item = new AccordionItem();
+
+        item.Toggle();
+
+        Assert.True(item.IsExpanded);
+    }
+
+    [Fact]
+    public void Toggle_FromExpanded_Collapses()
+    {
+        var item = new AccordionItem { IsExpanded = true };
+
+        item.Toggle();
+
+        Assert.False(item.IsExpanded);
+    }
+
+    [Fact]
+    public void ExpanderIcon_ReturnsCorrectGlyph()
+    {
+        var item = new AccordionItem();
+        Assert.Equal("▶", item.ExpanderIcon);
+
+        item.IsExpanded = true;
+        Assert.Equal("▼", item.ExpanderIcon);
+    }
+
+    [Fact]
+    public void PropertyDefaults_AreCorrect()
+    {
+        var item = new AccordionItem();
+
+        Assert.Null(item.Header);
+        Assert.Null(item.HeaderTemplate);
+        Assert.Null(item.Icon);
+        Assert.True(item.IsEnabled);
+        Assert.False(item.IsExpanded);
+        Assert.Null(item.ExpandCommand);
+        Assert.Null(item.CollapseCommand);
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/BreadcrumbItemTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/BreadcrumbItemTests.cs
@@ -1,0 +1,124 @@
+using System.ComponentModel;
+using MauiControlsExtras.Controls;
+using MauiControlsExtras.Tests.Helpers;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class BreadcrumbItemTests
+{
+    [Fact]
+    public void DefaultConstructor_SetsDefaults()
+    {
+        var item = new BreadcrumbItem();
+
+        Assert.Null(item.Text);
+        Assert.Null(item.Icon);
+        Assert.Null(item.Tag);
+        Assert.True(item.IsEnabled);
+        Assert.False(item.IsCurrent);
+        Assert.Null(item.Command);
+        Assert.Null(item.CommandParameter);
+    }
+
+    [Fact]
+    public void Constructor_WithText_SetsText()
+    {
+        var item = new BreadcrumbItem("Home");
+
+        Assert.Equal("Home", item.Text);
+    }
+
+    [Fact]
+    public void Constructor_WithTextAndIcon_SetsBoth()
+    {
+        var item = new BreadcrumbItem("Home", "🏠");
+
+        Assert.Equal("Home", item.Text);
+        Assert.Equal("🏠", item.Icon);
+    }
+
+    [Fact]
+    public void Text_RaisesPropertyChanged()
+    {
+        var item = new BreadcrumbItem();
+        var raised = false;
+        item.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(BreadcrumbItem.Text)) raised = true;
+        };
+
+        item.Text = "Products";
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Text_DoesNotRaise_WhenSameValue()
+    {
+        var item = new BreadcrumbItem("Home");
+        var raised = false;
+        item.PropertyChanged += (_, _) => raised = true;
+
+        item.Text = "Home";
+
+        Assert.False(raised);
+    }
+
+    [Fact]
+    public void Icon_RaisesPropertyChanged()
+    {
+        var item = new BreadcrumbItem();
+        var raised = false;
+        item.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(BreadcrumbItem.Icon)) raised = true;
+        };
+
+        item.Icon = "📁";
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Tag_RaisesPropertyChanged()
+    {
+        var item = new BreadcrumbItem();
+        var raised = false;
+        item.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(BreadcrumbItem.Tag)) raised = true;
+        };
+
+        item.Tag = new object();
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void IsEnabled_RaisesPropertyChanged()
+    {
+        var item = new BreadcrumbItem();
+        var raised = false;
+        item.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(BreadcrumbItem.IsEnabled)) raised = true;
+        };
+
+        item.IsEnabled = false;
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Command_CanBeSetAndRetrieved()
+    {
+        var item = new BreadcrumbItem();
+        var cmd = new TestCommand();
+
+        item.Command = cmd;
+        item.CommandParameter = "param";
+
+        Assert.Same(cmd, item.Command);
+        Assert.Equal("param", item.CommandParameter);
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/ContextMenuItemCollectionTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/ContextMenuItemCollectionTests.cs
@@ -1,0 +1,141 @@
+using MauiControlsExtras.ContextMenu;
+using MauiControlsExtras.Tests.Helpers;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class ContextMenuItemCollectionTests
+{
+    [Fact]
+    public void AddSeparator_AddsSeparatorItem()
+    {
+        var collection = new ContextMenuItemCollection();
+
+        collection.AddSeparator();
+
+        Assert.Single(collection);
+        Assert.True(collection[0].IsSeparator);
+    }
+
+    [Fact]
+    public void Add_WithAction_CreatesAndAddsItem()
+    {
+        var collection = new ContextMenuItemCollection();
+
+        var item = collection.Add("Copy", () => { }, "📋", "Ctrl+C");
+
+        Assert.Single(collection);
+        Assert.Equal("Copy", item.Text);
+        Assert.Equal("📋", item.IconGlyph);
+        Assert.Equal("Ctrl+C", item.KeyboardShortcut);
+    }
+
+    [Fact]
+    public void Add_WithCommand_CreatesAndAddsItem()
+    {
+        var collection = new ContextMenuItemCollection();
+        var cmd = new TestCommand();
+
+        var item = collection.Add("Save", cmd, "data", "💾");
+
+        Assert.Single(collection);
+        Assert.Same(cmd, item.Command);
+        Assert.Equal("data", item.CommandParameter);
+    }
+
+    [Fact]
+    public void AddSubMenu_CreatesSubmenuItem()
+    {
+        var collection = new ContextMenuItemCollection();
+        var children = new[] { new ContextMenuItem { Text = "A" } };
+
+        var item = collection.AddSubMenu("Format", children);
+
+        Assert.Single(collection);
+        Assert.True(item.HasSubItems);
+        Assert.Single(item.SubItems);
+    }
+
+    [Fact]
+    public void AddSubMenu_WithBuilder_PopulatesSubItems()
+    {
+        var collection = new ContextMenuItemCollection();
+
+        var item = collection.AddSubMenu("Edit", sub =>
+        {
+            sub.Add("Cut", () => { });
+            sub.Add("Copy", () => { });
+        });
+
+        Assert.Equal(2, item.SubItems.Count);
+    }
+
+    [Fact]
+    public void AddRange_AddsMultipleItems()
+    {
+        var collection = new ContextMenuItemCollection();
+        var items = new[]
+        {
+            new ContextMenuItem { Text = "A" },
+            new ContextMenuItem { Text = "B" },
+            new ContextMenuItem { Text = "C" }
+        };
+
+        collection.AddRange(items);
+
+        Assert.Equal(3, collection.Count);
+    }
+
+    [Fact]
+    public void FindByText_FindsVisibleItem()
+    {
+        var collection = new ContextMenuItemCollection();
+        collection.Add(new ContextMenuItem { Text = "Copy", IsVisible = true });
+        collection.Add(new ContextMenuItem { Text = "Paste", IsVisible = false });
+
+        var found = collection.FindByText("Copy");
+        var notFound = collection.FindByText("Paste");
+
+        Assert.NotNull(found);
+        Assert.Equal("Copy", found.Text);
+        Assert.Null(notFound);
+    }
+
+    [Fact]
+    public void FindByText_ReturnsNull_WhenNotFound()
+    {
+        var collection = new ContextMenuItemCollection();
+
+        Assert.Null(collection.FindByText("Missing"));
+    }
+
+    [Fact]
+    public void InsertSeparator_InsertsAtIndex()
+    {
+        var collection = new ContextMenuItemCollection
+        {
+            new ContextMenuItem { Text = "A" },
+            new ContextMenuItem { Text = "B" }
+        };
+
+        collection.InsertSeparator(1);
+
+        Assert.Equal(3, collection.Count);
+        Assert.True(collection[1].IsSeparator);
+    }
+
+    [Fact]
+    public void GetVisibleItems_FiltersInvisible()
+    {
+        var collection = new ContextMenuItemCollection
+        {
+            new ContextMenuItem { Text = "Visible", IsVisible = true },
+            new ContextMenuItem { Text = "Hidden", IsVisible = false },
+            new ContextMenuItem { Text = "AlsoVisible", IsVisible = true }
+        };
+
+        var visible = collection.GetVisibleItems().ToList();
+
+        Assert.Equal(2, visible.Count);
+        Assert.DoesNotContain(visible, i => i.Text == "Hidden");
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/ContextMenuItemTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/ContextMenuItemTests.cs
@@ -1,0 +1,194 @@
+using MauiControlsExtras.ContextMenu;
+using MauiControlsExtras.Tests.Helpers;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class ContextMenuItemTests
+{
+    [Fact]
+    public void Execute_WithCommand_ExecutesCommand()
+    {
+        var cmd = new TestCommand();
+        var item = new ContextMenuItem { Command = cmd };
+
+        item.Execute();
+
+        Assert.True(cmd.WasExecuted);
+    }
+
+    [Fact]
+    public void Execute_WithCommandParameter_PassesParameter()
+    {
+        var cmd = new TestCommand();
+        var item = new ContextMenuItem { Command = cmd, CommandParameter = "test" };
+
+        item.Execute();
+
+        Assert.Equal("test", cmd.LastParameter);
+    }
+
+    [Fact]
+    public void Execute_WithAction_InvokesAction()
+    {
+        var invoked = false;
+        var item = new ContextMenuItem { Action = () => invoked = true };
+
+        item.Execute();
+
+        Assert.True(invoked);
+    }
+
+    [Fact]
+    public void Execute_WhenDisabled_DoesNotExecute()
+    {
+        var cmd = new TestCommand();
+        var item = new ContextMenuItem { Command = cmd, IsEnabled = false };
+
+        item.Execute();
+
+        Assert.False(cmd.WasExecuted);
+    }
+
+    [Fact]
+    public void Execute_WithCommandAndAction_PrefersCommand()
+    {
+        var cmdExecuted = false;
+        var actionExecuted = false;
+        var cmd = new TestCommand(_ => cmdExecuted = true);
+        var item = new ContextMenuItem
+        {
+            Command = cmd,
+            Action = () => actionExecuted = true
+        };
+
+        item.Execute();
+
+        Assert.True(cmdExecuted);
+        Assert.False(actionExecuted);
+    }
+
+    [Fact]
+    public void Execute_WithCanExecuteFalse_FallsToAction()
+    {
+        var actionExecuted = false;
+        var cmd = new TestCommand(canExecute: _ => false);
+        var item = new ContextMenuItem
+        {
+            Command = cmd,
+            Action = () => actionExecuted = true
+        };
+
+        item.Execute();
+
+        Assert.True(actionExecuted);
+    }
+
+    [Fact]
+    public void CanExecute_WhenDisabled_ReturnsFalse()
+    {
+        var cmd = new TestCommand();
+        var item = new ContextMenuItem { Command = cmd, IsEnabled = false };
+
+        Assert.False(item.CanExecute());
+    }
+
+    [Fact]
+    public void CanExecute_WithCommand_DelegatesToCommand()
+    {
+        var cmd = new TestCommand(canExecute: _ => true);
+        var item = new ContextMenuItem { Command = cmd };
+
+        Assert.True(item.CanExecute());
+    }
+
+    [Fact]
+    public void CanExecute_WithAction_ReturnsTrue()
+    {
+        var item = new ContextMenuItem { Action = () => { } };
+
+        Assert.True(item.CanExecute());
+    }
+
+    [Fact]
+    public void CanExecute_WithSubItems_ReturnsTrue()
+    {
+        var item = new ContextMenuItem();
+        item.SubItems.Add(new ContextMenuItem { Text = "Child" });
+
+        Assert.True(item.CanExecute());
+    }
+
+    [Fact]
+    public void CanExecute_WithNothing_ReturnsFalse()
+    {
+        var item = new ContextMenuItem();
+
+        Assert.False(item.CanExecute());
+    }
+
+    [Fact]
+    public void Separator_Factory_CreatesSeparator()
+    {
+        var sep = ContextMenuItem.Separator();
+
+        Assert.True(sep.IsSeparator);
+    }
+
+    [Fact]
+    public void Create_WithAction_SetsProperties()
+    {
+        var item = ContextMenuItem.Create("Copy", () => { }, "📋", "Ctrl+C");
+
+        Assert.Equal("Copy", item.Text);
+        Assert.NotNull(item.Action);
+        Assert.Equal("📋", item.IconGlyph);
+        Assert.Equal("Ctrl+C", item.KeyboardShortcut);
+    }
+
+    [Fact]
+    public void Create_WithCommand_SetsProperties()
+    {
+        var cmd = new TestCommand();
+        var item = ContextMenuItem.Create("Save", cmd, "data", "💾", "Ctrl+S");
+
+        Assert.Equal("Save", item.Text);
+        Assert.Same(cmd, item.Command);
+        Assert.Equal("data", item.CommandParameter);
+        Assert.Equal("💾", item.IconGlyph);
+        Assert.Equal("Ctrl+S", item.KeyboardShortcut);
+    }
+
+    [Fact]
+    public void CreateSubMenu_CreatesItemWithSubItems()
+    {
+        var children = new[]
+        {
+            new ContextMenuItem { Text = "A" },
+            new ContextMenuItem { Text = "B" }
+        };
+
+        var item = ContextMenuItem.CreateSubMenu("Format", children, "✎");
+
+        Assert.Equal("Format", item.Text);
+        Assert.Equal("✎", item.IconGlyph);
+        Assert.True(item.HasSubItems);
+        Assert.Equal(2, item.SubItems.Count);
+    }
+
+    [Fact]
+    public void PropertyDefaults_AreCorrect()
+    {
+        var item = new ContextMenuItem();
+
+        Assert.Null(item.Text);
+        Assert.Null(item.Icon);
+        Assert.Null(item.IconGlyph);
+        Assert.Null(item.Command);
+        Assert.Null(item.CommandParameter);
+        Assert.True(item.IsEnabled);
+        Assert.True(item.IsVisible);
+        Assert.False(item.IsSeparator);
+        Assert.Null(item.KeyboardShortcut);
+        Assert.False(item.HasSubItems);
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/DataGridColumnTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/DataGridColumnTests.cs
@@ -1,0 +1,139 @@
+using System.ComponentModel;
+using MauiControlsExtras.Controls;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class DataGridColumnTests
+{
+    [Fact]
+    public void TextColumn_PropertyDefaults()
+    {
+        var col = new DataGridTextColumn();
+
+        Assert.Equal(string.Empty, col.Header);
+        Assert.Equal(-1, col.Width); // auto
+        Assert.Equal(50, col.MinWidth);
+        Assert.True(col.CanUserSort);
+        Assert.True(col.CanUserFilter);
+        Assert.True(col.CanUserEdit);
+        Assert.True(col.CanUserResize);
+        Assert.True(col.CanUserReorder);
+        Assert.False(col.IsReadOnly);
+        Assert.True(col.IsVisible);
+    }
+
+    [Fact]
+    public void Header_RaisesPropertyChanged()
+    {
+        var col = new DataGridTextColumn();
+        var raised = false;
+        col.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(DataGridColumn.Header)) raised = true;
+        };
+
+        col.Header = "Name";
+
+        Assert.True(raised);
+        Assert.Equal("Name", col.Header);
+    }
+
+    [Fact]
+    public void Width_RaisesPropertyChanged()
+    {
+        var col = new DataGridTextColumn();
+        var raised = false;
+        col.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(DataGridColumn.Width)) raised = true;
+        };
+
+        col.Width = 200;
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void SortDirection_RaisesPropertyChanged()
+    {
+        var col = new DataGridTextColumn();
+        var raised = false;
+        col.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(DataGridColumn.SortDirection)) raised = true;
+        };
+
+        col.SortDirection = SortDirection.Ascending;
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void IsVisible_RaisesPropertyChanged()
+    {
+        var col = new DataGridTextColumn();
+        var raised = false;
+        col.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(DataGridColumn.IsVisible)) raised = true;
+        };
+
+        col.IsVisible = false;
+
+        Assert.True(raised);
+        Assert.False(col.IsVisible);
+    }
+
+    [Fact]
+    public void TextColumn_CanSetBinding()
+    {
+        var col = new DataGridTextColumn { Binding = "Name" };
+
+        Assert.Equal("Name", col.Binding);
+    }
+
+    [Fact]
+    public void CheckBoxColumn_DefaultBinding()
+    {
+        var col = new DataGridCheckBoxColumn();
+
+        Assert.Equal(string.Empty, col.Binding);
+    }
+
+    [Fact]
+    public void ImageColumn_DefaultImageSize()
+    {
+        var col = new DataGridImageColumn();
+
+        Assert.Equal(32, col.ImageSize);
+    }
+
+    [Fact]
+    public void TemplateColumn_HasNullTemplates()
+    {
+        var col = new DataGridTemplateColumn();
+
+        Assert.Null(col.CellTemplate);
+        Assert.Null(col.EditTemplate);
+    }
+
+    [Fact]
+    public void AggregateType_CanBeSet()
+    {
+        var col = new DataGridTextColumn { AggregateType = DataGridAggregateType.Sum };
+
+        Assert.Equal(DataGridAggregateType.Sum, col.AggregateType);
+    }
+
+    [Fact]
+    public void ValidationFunc_CanBeSet()
+    {
+        var col = new DataGridTextColumn();
+        col.ValidationFunc = (item, value) =>
+            value != null
+                ? MauiControlsExtras.Base.Validation.ValidationResult.Success
+                : MauiControlsExtras.Base.Validation.ValidationResult.Failure("Required");
+
+        Assert.NotNull(col.ValidationFunc);
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/EventArgsTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/EventArgsTests.cs
@@ -1,0 +1,421 @@
+using MauiControlsExtras.Controls;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class EventArgsTests
+{
+    #region Accordion Event Args
+
+    [Fact]
+    public void AccordionItemExpandedEventArgs_StoresProperties()
+    {
+        var item = new AccordionItem { Header = "Test" };
+        var args = new AccordionItemExpandedEventArgs(item, 2, true);
+
+        Assert.Same(item, args.Item);
+        Assert.Equal(2, args.Index);
+        Assert.True(args.IsExpanded);
+    }
+
+    [Fact]
+    public void AccordionItemExpandingEventArgs_IsCancelable()
+    {
+        var item = new AccordionItem();
+        var args = new AccordionItemExpandingEventArgs(item, 0, true);
+
+        Assert.False(args.Cancel);
+        args.Cancel = true;
+        Assert.True(args.Cancel);
+        Assert.True(args.IsExpanding);
+    }
+
+    #endregion
+
+    #region Wizard Event Args
+
+    [Fact]
+    public void WizardStepChangedEventArgs_StoresProperties()
+    {
+        var oldStep = new WizardStep { Title = "Old" };
+        var newStep = new WizardStep { Title = "New" };
+        var args = new WizardStepChangedEventArgs(oldStep, newStep, 0, 1);
+
+        Assert.Same(oldStep, args.OldStep);
+        Assert.Same(newStep, args.NewStep);
+        Assert.Equal(0, args.OldIndex);
+        Assert.Equal(1, args.NewIndex);
+    }
+
+    [Fact]
+    public void WizardStepChangingEventArgs_IsCancelable()
+    {
+        var args = new WizardStepChangingEventArgs(null, null, 0, 1);
+
+        Assert.False(args.Cancel);
+        args.Cancel = true;
+        Assert.True(args.Cancel);
+    }
+
+    [Fact]
+    public void WizardFinishedEventArgs_StoresProperties()
+    {
+        var steps = new List<WizardStep> { new(), new() };
+        var args = new WizardFinishedEventArgs(true, steps);
+
+        Assert.True(args.WasCancelled);
+        Assert.Equal(2, args.Steps.Count);
+    }
+
+    [Fact]
+    public void WizardFinishingEventArgs_IsCancelable()
+    {
+        var steps = new List<WizardStep>();
+        var args = new WizardFinishingEventArgs(steps);
+
+        Assert.False(args.Cancel);
+        args.Cancel = true;
+        Assert.True(args.Cancel);
+    }
+
+    [Fact]
+    public void WizardCancellingEventArgs_StoresCurrentIndex()
+    {
+        var args = new WizardCancellingEventArgs(3);
+
+        Assert.Equal(3, args.CurrentIndex);
+        Assert.False(args.Cancel);
+    }
+
+    [Fact]
+    public void WizardStepValidatingEventArgs_ComputesDirection()
+    {
+        var forward = new WizardStepValidatingEventArgs(null, null, 0, 2);
+        Assert.Equal(WizardNavigationDirection.Forward, forward.Direction);
+
+        var backward = new WizardStepValidatingEventArgs(null, null, 2, 0);
+        Assert.Equal(WizardNavigationDirection.Backward, backward.Direction);
+    }
+
+    [Fact]
+    public void WizardStepValidatingEventArgs_HasMutableValidationErrors()
+    {
+        var args = new WizardStepValidatingEventArgs(null, null, 0, 1);
+        Assert.Empty(args.ValidationErrors);
+
+        args.ValidationErrors.Add("Field required");
+        Assert.Single(args.ValidationErrors);
+    }
+
+    [Fact]
+    public void WizardStepValidationEventArgs_StoresStepAndMessage()
+    {
+        var step = new WizardStep { Title = "Step 1" };
+        var args = new WizardStepValidationEventArgs(step, "Invalid input");
+
+        Assert.Same(step, args.Step);
+        Assert.Equal("Invalid input", args.Message);
+    }
+
+    #endregion
+
+    #region Breadcrumb Event Args
+
+    [Fact]
+    public void BreadcrumbItemClickedEventArgs_StoresProperties()
+    {
+        var item = new BreadcrumbItem("Home");
+        var args = new BreadcrumbItemClickedEventArgs(item, 0);
+
+        Assert.Same(item, args.Item);
+        Assert.Equal(0, args.Index);
+    }
+
+    [Fact]
+    public void BreadcrumbNavigatingEventArgs_IsCancelable()
+    {
+        var item = new BreadcrumbItem("Products");
+        var args = new BreadcrumbNavigatingEventArgs(item, 1);
+
+        Assert.Same(item, args.TargetItem);
+        Assert.Equal(1, args.TargetIndex);
+        Assert.False(args.Cancel);
+        args.Cancel = true;
+        Assert.True(args.Cancel);
+    }
+
+    #endregion
+
+    #region Calendar Event Args
+
+    [Fact]
+    public void CalendarDateSelectedEventArgs_StoresProperties()
+    {
+        var date = new DateTime(2025, 6, 15);
+        var args = new CalendarDateSelectedEventArgs(date, true);
+
+        Assert.Equal(date, args.Date);
+        Assert.True(args.IsSelected);
+    }
+
+    [Fact]
+    public void CalendarDateSelectingEventArgs_IsCancelable()
+    {
+        var date = new DateTime(2025, 12, 25);
+        var args = new CalendarDateSelectingEventArgs(date, false);
+
+        Assert.Equal(date, args.Date);
+        Assert.False(args.IsSelecting);
+        Assert.False(args.Cancel);
+        args.Cancel = true;
+        Assert.True(args.Cancel);
+    }
+
+    [Fact]
+    public void CalendarDisplayDateChangedEventArgs_StoresProperties()
+    {
+        var oldDate = new DateTime(2025, 1, 1);
+        var newDate = new DateTime(2025, 2, 1);
+        var args = new CalendarDisplayDateChangedEventArgs(oldDate, newDate);
+
+        Assert.Equal(oldDate, args.OldDate);
+        Assert.Equal(newDate, args.NewDate);
+    }
+
+    #endregion
+
+    #region DataGrid Event Args
+
+    [Fact]
+    public void DataGridCellEditEventArgs_StoresProperties()
+    {
+        var column = new DataGridTextColumn { Header = "Name" };
+        var item = new { Name = "Test" };
+        var args = new DataGridCellEditEventArgs(item, column, 0, 0, "old", "new");
+
+        Assert.Same(item, args.Item);
+        Assert.Same(column, args.Column);
+        Assert.Equal(0, args.RowIndex);
+        Assert.Equal(0, args.ColumnIndex);
+        Assert.Equal("old", args.OldValue);
+        Assert.Equal("new", args.NewValue);
+        Assert.False(args.Cancel);
+    }
+
+    [Fact]
+    public void DataGridRowEditEventArgs_StoresProperties()
+    {
+        var item = new { Name = "Test" };
+        var columns = new List<DataGridColumn> { new DataGridTextColumn() };
+        var args = new DataGridRowEditEventArgs(item, 5, columns);
+
+        Assert.Same(item, args.Item);
+        Assert.Equal(5, args.RowIndex);
+        Assert.Single(args.EditedColumns);
+    }
+
+    [Fact]
+    public void DataGridColumnEventArgs_StoresProperties()
+    {
+        var column = new DataGridTextColumn { Header = "Age" };
+        var args = new DataGridColumnEventArgs(column, 1);
+
+        Assert.Same(column, args.Column);
+        Assert.Equal(1, args.ColumnIndex);
+    }
+
+    #endregion
+
+    #region BindingNavigator Event Args
+
+    [Fact]
+    public void PositionChangedEventArgs_StoresProperties()
+    {
+        var args = new MauiControlsExtras.Controls.PositionChangedEventArgs(0, 5, "item5");
+
+        Assert.Equal(0, args.OldPosition);
+        Assert.Equal(5, args.NewPosition);
+        Assert.Equal("item5", args.Item);
+    }
+
+    [Fact]
+    public void PositionChangingEventArgs_IsCancelable()
+    {
+        var args = new MauiControlsExtras.Controls.PositionChangingEventArgs(3, 4);
+
+        Assert.Equal(3, args.CurrentPosition);
+        Assert.Equal(4, args.NewPosition);
+        Assert.False(args.Cancel);
+        args.Cancel = true;
+        Assert.True(args.Cancel);
+    }
+
+    [Fact]
+    public void BindingNavigatorItemEventArgs_IsCancelable()
+    {
+        var args = new MauiControlsExtras.Controls.BindingNavigatorItemEventArgs("record", 10);
+
+        Assert.Equal("record", args.Item);
+        Assert.Equal(10, args.Position);
+        Assert.False(args.Cancel);
+    }
+
+    #endregion
+
+    #region PropertyGrid Event Args
+
+    [Fact]
+    public void PropertyValueChangedEventArgs_StoresProperties()
+    {
+        var prop = CreateTestPropertyItem();
+        var args = new PropertyValueChangedEventArgs(prop, "old", "new");
+
+        Assert.Same(prop, args.Property);
+        Assert.Equal("old", args.OldValue);
+        Assert.Equal("new", args.NewValue);
+    }
+
+    [Fact]
+    public void PropertyValueChangingEventArgs_IsCancelable()
+    {
+        var prop = CreateTestPropertyItem();
+        var args = new PropertyValueChangingEventArgs(prop, "current", "proposed");
+
+        Assert.Same(prop, args.Property);
+        Assert.Equal("current", args.CurrentValue);
+        Assert.Equal("proposed", args.NewValue);
+        Assert.False(args.Cancel);
+        args.Cancel = true;
+        Assert.True(args.Cancel);
+    }
+
+    [Fact]
+    public void SelectedObjectChangedEventArgs_StoresProperties()
+    {
+        var oldObj = new object();
+        var newObj = new object();
+        var args = new SelectedObjectChangedEventArgs(oldObj, newObj);
+
+        Assert.Same(oldObj, args.OldObject);
+        Assert.Same(newObj, args.NewObject);
+    }
+
+    [Fact]
+    public void PropertySelectionChangedEventArgs_StoresProperties()
+    {
+        var args = new PropertySelectionChangedEventArgs(null, null);
+
+        Assert.Null(args.OldProperty);
+        Assert.Null(args.NewProperty);
+    }
+
+    #endregion
+
+    #region RichTextEditor Event Args
+
+    [Fact]
+    public void RichTextContentChangedEventArgs_StoresProperties()
+    {
+        var args = new RichTextContentChangedEventArgs("<p>old</p>", "<p>new</p>", ContentFormat.Html);
+
+        Assert.Equal("<p>old</p>", args.OldContent);
+        Assert.Equal("<p>new</p>", args.NewContent);
+        Assert.Equal(ContentFormat.Html, args.Format);
+    }
+
+    [Fact]
+    public void RichTextSelectionChangedEventArgs_HasSelectionComputed()
+    {
+        var withSelection = new RichTextSelectionChangedEventArgs(5, 10, "hello there");
+        Assert.True(withSelection.HasSelection);
+        Assert.Equal(5, withSelection.Start);
+        Assert.Equal(10, withSelection.Length);
+
+        var noSelection = new RichTextSelectionChangedEventArgs(5, 0, null);
+        Assert.False(noSelection.HasSelection);
+    }
+
+    [Fact]
+    public void RichTextLinkTappedEventArgs_StoresProperties()
+    {
+        var args = new RichTextLinkTappedEventArgs("https://example.com", "Example");
+
+        Assert.Equal("https://example.com", args.Url);
+        Assert.Equal("Example", args.Text);
+        Assert.False(args.Handled);
+    }
+
+    [Fact]
+    public void RichTextImageRequestedEventArgs_IsMutable()
+    {
+        var args = new RichTextImageRequestedEventArgs();
+
+        Assert.Null(args.ImageUrl);
+        args.ImageUrl = "img.png";
+        args.AltText = "Alt";
+        args.Handled = true;
+
+        Assert.Equal("img.png", args.ImageUrl);
+        Assert.Equal("Alt", args.AltText);
+        Assert.True(args.Handled);
+    }
+
+    [Fact]
+    public void RichTextFocusChangedEventArgs_StoresIsFocused()
+    {
+        var focused = new RichTextFocusChangedEventArgs(true);
+        Assert.True(focused.IsFocused);
+
+        var unfocused = new RichTextFocusChangedEventArgs(false);
+        Assert.False(unfocused.IsFocused);
+    }
+
+    #endregion
+
+    #region TokenEntry Event Args
+
+    [Fact]
+    public void TokenClipboardEventArgs_StoresProperties()
+    {
+        var tokens = new[] { "tag1", "tag2" };
+        var args = new TokenClipboardEventArgs(TokenClipboardOperation.Copy, tokens, "tag1, tag2");
+
+        Assert.Equal(TokenClipboardOperation.Copy, args.Operation);
+        Assert.Equal(2, args.Tokens.Count);
+        Assert.Equal("tag1, tag2", args.Content);
+        Assert.False(args.Cancel);
+    }
+
+    [Fact]
+    public void TokenClipboardEventArgs_SingleTokenConstructor()
+    {
+        var args = new TokenClipboardEventArgs(TokenClipboardOperation.Cut, "tag1");
+
+        Assert.Equal(TokenClipboardOperation.Cut, args.Operation);
+        Assert.Single(args.Tokens);
+        Assert.Equal("tag1", args.Content);
+    }
+
+    [Fact]
+    public void TokenClipboardEventArgs_PasteSkipTracking()
+    {
+        var args = new TokenClipboardEventArgs(TokenClipboardOperation.Paste, new[] { "a", "b" }, "a, b");
+
+        Assert.Empty(args.SkippedTokens);
+        Assert.Empty(args.SkipReasons);
+        Assert.Equal(0, args.SuccessCount);
+    }
+
+    #endregion
+
+    private static PropertyItem CreateTestPropertyItem()
+    {
+        var target = new SampleTarget { Name = "Test" };
+        var propInfo = typeof(SampleTarget).GetProperty(nameof(SampleTarget.Name))!;
+        return new PropertyItem(propInfo, target);
+    }
+
+    private class SampleTarget
+    {
+        public string Name { get; set; } = "";
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/PropertyCategoryTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/PropertyCategoryTests.cs
@@ -1,0 +1,96 @@
+using System.ComponentModel;
+using MauiControlsExtras.Controls;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class PropertyCategoryTests
+{
+    [Fact]
+    public void Constructor_SetsNameAndProperties()
+    {
+        var props = Array.Empty<PropertyItem>();
+        var category = new PropertyCategory("Layout", props);
+
+        Assert.Equal("Layout", category.Name);
+        Assert.Same(props, category.Properties);
+    }
+
+    [Fact]
+    public void PropertyCount_ReturnsCount()
+    {
+        var target = new TestObj();
+        var items = new[]
+        {
+            new PropertyItem(typeof(TestObj).GetProperty(nameof(TestObj.A))!, target),
+            new PropertyItem(typeof(TestObj).GetProperty(nameof(TestObj.B))!, target)
+        };
+        var category = new PropertyCategory("Test", items);
+
+        Assert.Equal(2, category.PropertyCount);
+    }
+
+    [Fact]
+    public void IsExpanded_DefaultsToTrue()
+    {
+        var category = new PropertyCategory("Test", Array.Empty<PropertyItem>());
+
+        Assert.True(category.IsExpanded);
+    }
+
+    [Fact]
+    public void IsExpanded_RaisesPropertyChanged()
+    {
+        var category = new PropertyCategory("Test", Array.Empty<PropertyItem>());
+        var raised = false;
+        category.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyCategory.IsExpanded)) raised = true;
+        };
+
+        category.IsExpanded = false;
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void ExpanderIcon_ReflectsState()
+    {
+        var category = new PropertyCategory("Test", Array.Empty<PropertyItem>());
+
+        Assert.Equal("▼", category.ExpanderIcon); // expanded
+
+        category.IsExpanded = false;
+        Assert.Equal("▶", category.ExpanderIcon); // collapsed
+    }
+
+    [Fact]
+    public void ToggleExpanded_TogglesState()
+    {
+        var category = new PropertyCategory("Test", Array.Empty<PropertyItem>());
+        Assert.True(category.IsExpanded);
+
+        category.ToggleExpanded();
+        Assert.False(category.IsExpanded);
+
+        category.ToggleExpanded();
+        Assert.True(category.IsExpanded);
+    }
+
+    [Fact]
+    public void ToggleExpanded_RaisesExpanderIconChanged()
+    {
+        var category = new PropertyCategory("Test", Array.Empty<PropertyItem>());
+        var changed = new List<string>();
+        category.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        category.ToggleExpanded();
+
+        Assert.Contains("ExpanderIcon", changed);
+    }
+
+    private class TestObj
+    {
+        public string A { get; set; } = "";
+        public int B { get; set; }
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/PropertyItemTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/PropertyItemTests.cs
@@ -1,0 +1,216 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using MauiControlsExtras.Controls;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class PropertyItemTests
+{
+    [Fact]
+    public void Constructor_ReadsPropertyValue()
+    {
+        var target = new SampleObject { Name = "Hello" };
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+
+        Assert.Equal("Hello", item.Value);
+    }
+
+    [Fact]
+    public void Constructor_ReadsDisplayName()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.DisplayNameProp));
+
+        Assert.Equal("Friendly Name", item.DisplayName);
+    }
+
+    [Fact]
+    public void Constructor_FallsBackToPropertyName_WhenNoDisplayNameAttr()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+
+        Assert.Equal("Name", item.DisplayName);
+    }
+
+    [Fact]
+    public void Constructor_ReadsDescription()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.DisplayNameProp));
+
+        Assert.Equal("A test description", item.Description);
+    }
+
+    [Fact]
+    public void Constructor_ReadsCategory()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.CategorizedProp));
+
+        Assert.Equal("Layout", item.Category);
+    }
+
+    [Fact]
+    public void Constructor_DefaultsCategory_ToMisc()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+
+        Assert.Equal("Misc", item.Category);
+    }
+
+    [Fact]
+    public void Constructor_DetectsReadOnly()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.ReadOnlyProp));
+
+        Assert.True(item.IsReadOnly);
+    }
+
+    [Fact]
+    public void Constructor_ReadsRange()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.RangeProp));
+
+        Assert.Equal(0, item.Minimum);
+        Assert.Equal(100, item.Maximum);
+    }
+
+    [Fact]
+    public void Value_Set_UpdatesTargetObject()
+    {
+        var target = new SampleObject { Name = "Old" };
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+
+        item.Value = "New";
+
+        Assert.Equal("New", target.Name);
+    }
+
+    [Fact]
+    public void Value_Set_RaisesValueChangedEvent()
+    {
+        var target = new SampleObject { Name = "Old" };
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+        PropertyValueChangedEventArgs? args = null;
+        item.ValueChanged += (_, e) => args = e;
+
+        item.Value = "New";
+
+        Assert.NotNull(args);
+        Assert.Equal("Old", args.OldValue);
+        Assert.Equal("New", args.NewValue);
+    }
+
+    [Fact]
+    public void Value_Set_RaisesPropertyChanged()
+    {
+        var target = new SampleObject { Name = "Old" };
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+        var changed = new List<string>();
+        item.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        item.Value = "New";
+
+        Assert.Contains("Value", changed);
+        Assert.Contains("DisplayValue", changed);
+    }
+
+    [Fact]
+    public void DisplayValue_FormatsNull()
+    {
+        var target = new SampleObject { Name = null! };
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+
+        Assert.Equal("(null)", item.DisplayValue);
+    }
+
+    [Fact]
+    public void RefreshValue_UpdatesFromTarget()
+    {
+        var target = new SampleObject { Name = "Initial" };
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+
+        target.Name = "Changed";
+        item.RefreshValue();
+
+        Assert.Equal("Changed", item.Value);
+    }
+
+    [Fact]
+    public void IsExpanded_RaisesPropertyChanged()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+        var raised = false;
+        item.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.IsExpanded)) raised = true;
+        };
+
+        item.IsExpanded = true;
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void IsSelected_RaisesPropertyChanged()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+        var raised = false;
+        item.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(PropertyItem.IsSelected)) raised = true;
+        };
+
+        item.IsSelected = true;
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void TypeName_ReturnsStringForString()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+
+        Assert.Equal("string", item.TypeName);
+    }
+
+    [Fact]
+    public void TypeName_ReturnsIntForInt()
+    {
+        var target = new SampleObject();
+        var item = CreatePropertyItem(target, nameof(SampleObject.RangeProp));
+
+        Assert.Equal("int", item.TypeName);
+    }
+
+    private static PropertyItem CreatePropertyItem(object target, string propertyName)
+    {
+        var propInfo = target.GetType().GetProperty(propertyName)!;
+        return new PropertyItem(propInfo, target);
+    }
+
+    private class SampleObject
+    {
+        public string Name { get; set; } = "";
+
+        [DisplayName("Friendly Name")]
+        [Description("A test description")]
+        public string DisplayNameProp { get; set; } = "";
+
+        [Category("Layout")]
+        public double CategorizedProp { get; set; }
+
+        [ReadOnly(true)]
+        public string ReadOnlyProp { get; set; } = "Readonly";
+
+        [Range(0, 100)]
+        public int RangeProp { get; set; }
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/ToolbarConfigTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/ToolbarConfigTests.cs
@@ -1,0 +1,87 @@
+using MauiControlsExtras.Controls;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class ToolbarConfigTests
+{
+    [Fact]
+    public void Standard_HasDefaultButtons()
+    {
+        var config = ToolbarConfig.Standard;
+
+        Assert.True(config.Bold);
+        Assert.True(config.Italic);
+        Assert.True(config.Underline);
+        Assert.True(config.BulletList);
+        Assert.True(config.NumberedList);
+        Assert.True(config.Heading);
+        Assert.True(config.Quote);
+        Assert.True(config.Link);
+        Assert.True(config.Undo);
+        Assert.True(config.Redo);
+        Assert.True(config.ClearFormatting);
+        Assert.False(config.Strikethrough);
+        Assert.False(config.CodeBlock);
+        Assert.False(config.Image);
+    }
+
+    [Fact]
+    public void Minimal_HasOnlyBoldItalicLink()
+    {
+        var config = ToolbarConfig.Minimal;
+
+        Assert.True(config.Bold);
+        Assert.True(config.Italic);
+        Assert.True(config.Link);
+        Assert.False(config.Underline);
+        Assert.False(config.BulletList);
+        Assert.False(config.NumberedList);
+        Assert.False(config.Heading);
+        Assert.False(config.Quote);
+        Assert.False(config.Undo);
+        Assert.False(config.Redo);
+        Assert.False(config.ClearFormatting);
+    }
+
+    [Fact]
+    public void Full_HasAllButtonsEnabled()
+    {
+        var config = ToolbarConfig.Full;
+
+        Assert.True(config.Bold);
+        Assert.True(config.Italic);
+        Assert.True(config.Underline);
+        Assert.True(config.Strikethrough);
+        Assert.True(config.BulletList);
+        Assert.True(config.NumberedList);
+        Assert.True(config.Heading);
+        Assert.True(config.Quote);
+        Assert.True(config.CodeBlock);
+        Assert.True(config.Link);
+        Assert.True(config.Image);
+        Assert.True(config.Undo);
+        Assert.True(config.Redo);
+        Assert.True(config.ClearFormatting);
+    }
+
+    [Fact]
+    public void None_HasAllButtonsDisabled()
+    {
+        var config = ToolbarConfig.None;
+
+        Assert.False(config.Bold);
+        Assert.False(config.Italic);
+        Assert.False(config.Underline);
+        Assert.False(config.Strikethrough);
+        Assert.False(config.BulletList);
+        Assert.False(config.NumberedList);
+        Assert.False(config.Heading);
+        Assert.False(config.Quote);
+        Assert.False(config.CodeBlock);
+        Assert.False(config.Link);
+        Assert.False(config.Image);
+        Assert.False(config.Undo);
+        Assert.False(config.Redo);
+        Assert.False(config.ClearFormatting);
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Controls/WizardStepTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/WizardStepTests.cs
@@ -1,0 +1,249 @@
+using MauiControlsExtras.Controls;
+using MauiControlsExtras.Tests.Helpers;
+
+namespace MauiControlsExtras.Tests.Controls;
+
+public class WizardStepTests
+{
+    [Fact]
+    public void Validate_WhenOptional_ReturnsTrue()
+    {
+        var step = new WizardStep { IsOptional = true, IsValid = false };
+
+        var result = step.Validate();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Validate_ExecutesValidationCommand()
+    {
+        var step = new WizardStep();
+        var cmd = new TestCommand(param =>
+        {
+            if (param is WizardStep s) s.IsValid = true;
+        });
+        step.ValidationCommand = cmd;
+
+        step.Validate();
+
+        Assert.True(cmd.WasExecuted);
+    }
+
+    [Fact]
+    public void Validate_UsesValidationCommandParameter_WhenSet()
+    {
+        var step = new WizardStep();
+        var cmd = new TestCommand();
+        step.ValidationCommand = cmd;
+        step.ValidationCommandParameter = "custom";
+
+        step.Validate();
+
+        Assert.Equal("custom", cmd.LastParameter);
+    }
+
+    [Fact]
+    public void Validate_PassesSelfAsParameter_WhenNoParameterSet()
+    {
+        var step = new WizardStep();
+        var cmd = new TestCommand();
+        step.ValidationCommand = cmd;
+
+        step.Validate();
+
+        Assert.Same(step, cmd.LastParameter);
+    }
+
+    [Fact]
+    public void Validate_WhenInvalid_RaisesValidationFailed()
+    {
+        var step = new WizardStep { IsValid = false, ValidationMessage = "Required" };
+        WizardStepValidationEventArgs? args = null;
+        step.ValidationFailed += (_, e) => args = e;
+
+        step.Validate();
+
+        Assert.NotNull(args);
+        Assert.Same(step, args.Step);
+        Assert.Equal("Required", args.Message);
+    }
+
+    [Fact]
+    public void Validate_WhenValid_DoesNotRaiseValidationFailed()
+    {
+        var step = new WizardStep { IsValid = true };
+        var raised = false;
+        step.ValidationFailed += (_, _) => raised = true;
+
+        step.Validate();
+
+        Assert.False(raised);
+    }
+
+    [Fact]
+    public void Validate_ReturnsFalse_WhenIsValidIsFalse()
+    {
+        var step = new WizardStep { IsValid = false };
+
+        var result = step.Validate();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void OnEnter_SetsStatusToCurrent()
+    {
+        var step = new WizardStep();
+
+        step.OnEnter();
+
+        Assert.Equal(WizardStepStatus.Current, step.Status);
+        Assert.True(step.IsCurrent);
+    }
+
+    [Fact]
+    public void OnEnter_ExecutesOnEnterCommand()
+    {
+        var step = new WizardStep();
+        var cmd = new TestCommand();
+        step.OnEnterCommand = cmd;
+
+        step.OnEnter();
+
+        Assert.True(cmd.WasExecuted);
+    }
+
+    [Fact]
+    public void OnEnter_UsesOnEnterCommandParameter_WhenSet()
+    {
+        var step = new WizardStep();
+        var cmd = new TestCommand();
+        step.OnEnterCommand = cmd;
+        step.OnEnterCommandParameter = "enter-param";
+
+        step.OnEnter();
+
+        Assert.Equal("enter-param", cmd.LastParameter);
+    }
+
+    [Fact]
+    public void OnEnter_RaisesEnteredEvent()
+    {
+        var step = new WizardStep();
+        var raised = false;
+        step.Entered += (_, _) => raised = true;
+
+        step.OnEnter();
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void OnExit_WhenCompleted_SetsStatusToCompleted()
+    {
+        var step = new WizardStep();
+        step.OnEnter();
+
+        step.OnExit(completed: true);
+
+        Assert.Equal(WizardStepStatus.Completed, step.Status);
+        Assert.True(step.IsCompleted);
+    }
+
+    [Fact]
+    public void OnExit_WhenNotCompleted_KeepsCurrentStatus()
+    {
+        var step = new WizardStep();
+        step.OnEnter();
+
+        step.OnExit(completed: false);
+
+        Assert.Equal(WizardStepStatus.Current, step.Status);
+    }
+
+    [Fact]
+    public void OnExit_ExecutesOnExitCommand()
+    {
+        var step = new WizardStep();
+        var cmd = new TestCommand();
+        step.OnExitCommand = cmd;
+
+        step.OnExit(completed: true);
+
+        Assert.True(cmd.WasExecuted);
+    }
+
+    [Fact]
+    public void OnExit_RaisesExitedEvent()
+    {
+        var step = new WizardStep();
+        var raised = false;
+        step.Exited += (_, _) => raised = true;
+
+        step.OnExit(completed: true);
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Status_RaisesPropertyChanged()
+    {
+        var step = new WizardStep();
+        var changed = new List<string>();
+        step.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        step.OnEnter();
+
+        Assert.Contains("Status", changed);
+        Assert.Contains("IsCurrent", changed);
+        Assert.Contains("IsCompleted", changed);
+    }
+
+    [Fact]
+    public void IsValid_RaisesPropertyChanged()
+    {
+        var step = new WizardStep();
+        var changed = false;
+        step.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == "IsValid") changed = true;
+        };
+
+        step.IsValid = false;
+
+        Assert.True(changed);
+    }
+
+    [Fact]
+    public void ValidationMessage_RaisesPropertyChanged()
+    {
+        var step = new WizardStep();
+        var changed = false;
+        step.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == "ValidationMessage") changed = true;
+        };
+
+        step.ValidationMessage = "Error";
+
+        Assert.True(changed);
+    }
+
+    [Fact]
+    public void PropertyDefaults_AreCorrect()
+    {
+        var step = new WizardStep();
+
+        Assert.Null(step.Title);
+        Assert.Null(step.Description);
+        Assert.Null(step.Icon);
+        Assert.False(step.CanSkip);
+        Assert.False(step.IsOptional);
+        Assert.True(step.IsValid);
+        Assert.Null(step.ValidationMessage);
+        Assert.Equal(WizardStepStatus.NotVisited, step.Status);
+        Assert.False(step.IsCompleted);
+        Assert.False(step.IsCurrent);
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Helpers/TestCommand.cs
+++ b/tests/MauiControlsExtras.Tests/Helpers/TestCommand.cs
@@ -1,0 +1,38 @@
+using System.Windows.Input;
+
+namespace MauiControlsExtras.Tests.Helpers;
+
+/// <summary>
+/// Simple ICommand implementation for verifying command execution in tests.
+/// </summary>
+public class TestCommand : ICommand
+{
+    private readonly Func<object?, bool>? _canExecute;
+    private readonly Action<object?> _execute;
+
+    public int ExecuteCount { get; private set; }
+    public object? LastParameter { get; private set; }
+    public bool WasExecuted => ExecuteCount > 0;
+
+    public TestCommand(Action<object?>? execute = null, Func<object?, bool>? canExecute = null)
+    {
+        _execute = execute ?? (_ => { });
+        _canExecute = canExecute;
+    }
+
+    public bool CanExecute(object? parameter)
+    {
+        return _canExecute?.Invoke(parameter) ?? true;
+    }
+
+    public void Execute(object? parameter)
+    {
+        LastParameter = parameter;
+        ExecuteCount++;
+        _execute(parameter);
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj
+++ b/tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj
@@ -22,6 +22,8 @@
 
   <ItemGroup>
     <!-- Include source files for unit testing without platform-specific handlers -->
+
+    <!-- Base classes (existing) -->
     <Compile Include="..\..\src\MauiControlsExtras\Base\Validation\ValidationResult.cs" Link="Linked\Base\Validation\ValidationResult.cs" />
     <Compile Include="..\..\src\MauiControlsExtras\Theming\IThemeAware.cs" Link="Linked\Theming\IThemeAware.cs" />
     <Compile Include="..\..\src\MauiControlsExtras\Theming\ControlsTheme.cs" Link="Linked\Theming\ControlsTheme.cs" />
@@ -32,6 +34,72 @@
     <Compile Include="..\..\src\MauiControlsExtras\Base\NavigationControlBase.cs" Link="Linked\Base\NavigationControlBase.cs" />
     <Compile Include="..\..\src\MauiControlsExtras\Base\ListStyledControlBase.cs" Link="Linked\Base\ListStyledControlBase.cs" />
     <Compile Include="..\..\src\MauiControlsExtras\Base\AnimatedControlBase.cs" Link="Linked\Base\AnimatedControlBase.cs" />
+
+    <!-- Base interfaces (excluding IContextMenuSupport which depends on ContextMenuOpeningEventArgs) -->
+    <Compile Include="..\..\src\MauiControlsExtras\Base\IKeyboardNavigable.cs" Link="Linked\Base\IKeyboardNavigable.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Base\IClipboardSupport.cs" Link="Linked\Base\IClipboardSupport.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Base\ISelectable.cs" Link="Linked\Base\ISelectable.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Base\IUndoRedo.cs" Link="Linked\Base\IUndoRedo.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Base\Validation\IValidatable.cs" Link="Linked\Base\Validation\IValidatable.cs" />
+
+    <!-- Converters -->
+    <Compile Include="..\..\src\MauiControlsExtras\Converters\InvertedBoolConverter.cs" Link="Linked\Converters\InvertedBoolConverter.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Converters\MauiAssetImageConverter.cs" Link="Linked\Converters\MauiAssetImageConverter.cs" />
+
+    <!-- ContextMenu (core types only) -->
+    <Compile Include="..\..\src\MauiControlsExtras\ContextMenu\ContextMenuItem.cs" Link="Linked\ContextMenu\ContextMenuItem.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\ContextMenu\ContextMenuItemCollection.cs" Link="Linked\ContextMenu\ContextMenuItemCollection.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\ContextMenu\IContextMenuService.cs" Link="Linked\ContextMenu\IContextMenuService.cs" />
+
+    <!-- Accordion -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Accordion\AccordionItem.cs" Link="Linked\Controls\Accordion\AccordionItem.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Accordion\AccordionEnums.cs" Link="Linked\Controls\Accordion\AccordionEnums.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Accordion\AccordionEventArgs.cs" Link="Linked\Controls\Accordion\AccordionEventArgs.cs" />
+
+    <!-- Wizard -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Wizard\WizardStep.cs" Link="Linked\Controls\Wizard\WizardStep.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Wizard\WizardEnums.cs" Link="Linked\Controls\Wizard\WizardEnums.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Wizard\WizardEventArgs.cs" Link="Linked\Controls\Wizard\WizardEventArgs.cs" />
+
+    <!-- Breadcrumb -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Breadcrumb\BreadcrumbItem.cs" Link="Linked\Controls\Breadcrumb\BreadcrumbItem.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Breadcrumb\BreadcrumbEventArgs.cs" Link="Linked\Controls\Breadcrumb\BreadcrumbEventArgs.cs" />
+
+    <!-- Calendar -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Calendar\CalendarEnums.cs" Link="Linked\Controls\Calendar\CalendarEnums.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\Calendar\CalendarEventArgs.cs" Link="Linked\Controls\Calendar\CalendarEventArgs.cs" />
+
+    <!-- DataGrid (columns, enums, events - no ComboBoxColumn/UndoOps/Exporter which depend on full controls) -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\DataGrid\DataGridColumn.cs" Link="Linked\Controls\DataGrid\DataGridColumn.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\DataGrid\DataGridEnums.cs" Link="Linked\Controls\DataGrid\DataGridEnums.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\DataGrid\DataGridEventArgs.cs" Link="Linked\Controls\DataGrid\DataGridEventArgs.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\DataGrid\DataGridDatePickerColumn.cs" Link="Linked\Controls\DataGrid\DataGridDatePickerColumn.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\DataGrid\DataGridTimePickerColumn.cs" Link="Linked\Controls\DataGrid\DataGridTimePickerColumn.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\DataGrid\DataGridPrintOptions.cs" Link="Linked\Controls\DataGrid\DataGridPrintOptions.cs" />
+
+    <!-- PropertyGrid -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\PropertyGrid\PropertyItem.cs" Link="Linked\Controls\PropertyGrid\PropertyItem.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\PropertyGrid\PropertyCategory.cs" Link="Linked\Controls\PropertyGrid\PropertyCategory.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\PropertyGrid\PropertyGridEnums.cs" Link="Linked\Controls\PropertyGrid\PropertyGridEnums.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\PropertyGrid\PropertyGridEventArgs.cs" Link="Linked\Controls\PropertyGrid\PropertyGridEventArgs.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\PropertyGrid\IPropertyEditor.cs" Link="Linked\Controls\PropertyGrid\IPropertyEditor.cs" />
+
+    <!-- RichTextEditor (event args and enums only) -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\RichTextEditor\RichTextEditorEventArgs.cs" Link="Linked\Controls\RichTextEditor\RichTextEditorEventArgs.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\RichTextEditor\FormatType.cs" Link="Linked\Controls\RichTextEditor\FormatType.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\RichTextEditor\ToolbarConfig.cs" Link="Linked\Controls\RichTextEditor\ToolbarConfig.cs" />
+
+    <!-- BindingNavigator -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\BindingNavigator\BindingNavigatorEventArgs.cs" Link="Linked\Controls\BindingNavigator\BindingNavigatorEventArgs.cs" />
+
+    <!-- TokenEntry -->
+    <Compile Include="..\..\src\MauiControlsExtras\Controls\TokenEntryEventArgs.cs" Link="Linked\Controls\TokenEntryEventArgs.cs" />
+
+    <!-- Services (needed by DataGrid) -->
+    <Compile Include="..\..\src\MauiControlsExtras\Services\IPrintService.cs" Link="Linked\Services\IPrintService.cs" />
+
+    <!-- Behaviors (needed by IKeyboardNavigable) -->
+    <Compile Include="..\..\src\MauiControlsExtras\Behaviors\KeyboardBehavior.cs" Link="Linked\Behaviors\KeyboardBehavior.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Adds 142 new unit tests covering command execution, event raising, and control-specific logic for all testable control types (AccordionItem, WizardStep, BreadcrumbItem, ContextMenuItem, ContextMenuItemCollection, DataGridColumn, PropertyItem, PropertyCategory, ToolbarConfig, and all EventArgs)
- Adds `TestCommand` ICommand helper for verifying command execution in tests
- Updates test `.csproj` with linked source files for model classes, enums, event args, and interfaces

Closes #187

## Test plan
- [x] `dotnet test` — 346 tests pass (204 existing + 142 new), 0 failures
- [x] `dotnet build samples/DemoApp` — builds with 0 warnings, 0 errors
- [x] No regressions in existing tests