### PR TITLE
Fix #163: add IClipboardSupport to 4 text controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Clipboard**: `IClipboardSupport` implemented on ComboBox, MultiSelectComboBox, MaskedEntry, and NumericUpDown (#163)
+  - `CanCopy`, `CanCut`, `CanPaste` state properties reflect current control state
+  - `Copy()`, `Cut()`, `Paste()` programmatic methods delegate to underlying text input
+  - `CopyCommand`, `CutCommand`, `PasteCommand` bindable properties for MVVM
+  - Keyboard shortcuts Ctrl+C, Ctrl+X, Ctrl+V registered on all four controls
+  - NumericUpDown respects `IsReadOnly` for `CanCut`/`CanPaste`
 - **Tests**: Base class and theme system test coverage for `StyledControlBase`, `TextStyledControlBase`, `HeaderedControlBase`, `NavigationControlBase`, `ListStyledControlBase`, `AnimatedControlBase`, `ControlsTheme`, and `MauiControlsExtrasTheme` (#165)
 - **NumericUpDown**: Mouse wheel support to increment/decrement value when focused (#168)
 - **Rating**: Mouse wheel support to adjust rating when focused (#168)

--- a/src/MauiControlsExtras/Controls/NumericUpDown.xaml.cs
+++ b/src/MauiControlsExtras/Controls/NumericUpDown.xaml.cs
@@ -23,7 +23,7 @@ public enum ButtonPlacement
 /// <summary>
 /// A numeric input control with increment/decrement buttons.
 /// </summary>
-public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.IKeyboardNavigable
+public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.IKeyboardNavigable, Base.IClipboardSupport
 {
     #region Fields
 
@@ -208,6 +208,33 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
         typeof(ICommand),
         typeof(NumericUpDown));
 
+    /// <summary>
+    /// Identifies the <see cref="CopyCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CopyCommandProperty = BindableProperty.Create(
+        nameof(CopyCommand),
+        typeof(ICommand),
+        typeof(NumericUpDown),
+        default(ICommand));
+
+    /// <summary>
+    /// Identifies the <see cref="CutCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CutCommandProperty = BindableProperty.Create(
+        nameof(CutCommand),
+        typeof(ICommand),
+        typeof(NumericUpDown),
+        default(ICommand));
+
+    /// <summary>
+    /// Identifies the <see cref="PasteCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PasteCommandProperty = BindableProperty.Create(
+        nameof(PasteCommand),
+        typeof(ICommand),
+        typeof(NumericUpDown),
+        default(ICommand));
+
     #endregion
 
     #region Properties
@@ -359,6 +386,78 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
         get => (ICommand?)GetValue(ValidateCommandProperty);
         set => SetValue(ValidateCommandProperty, value);
     }
+
+    /// <inheritdoc />
+    public ICommand? CopyCommand
+    {
+        get => (ICommand?)GetValue(CopyCommandProperty);
+        set => SetValue(CopyCommandProperty, value);
+    }
+
+    /// <inheritdoc />
+    public ICommand? CutCommand
+    {
+        get => (ICommand?)GetValue(CutCommandProperty);
+        set => SetValue(CutCommandProperty, value);
+    }
+
+    /// <inheritdoc />
+    public ICommand? PasteCommand
+    {
+        get => (ICommand?)GetValue(PasteCommandProperty);
+        set => SetValue(PasteCommandProperty, value);
+    }
+
+    #endregion
+
+    #region IClipboardSupport
+
+    /// <inheritdoc />
+    public bool CanCopy => IsEnabled && _entry?.Text?.Length > 0;
+
+    /// <inheritdoc />
+    public bool CanCut => CanCopy && !IsReadOnly;
+
+    /// <inheritdoc />
+    public bool CanPaste => IsEnabled && !IsReadOnly;
+
+    /// <inheritdoc />
+    public void Copy()
+    {
+        if (!CanCopy) return;
+        var content = GetClipboardContent();
+        if (content is string text)
+            Clipboard.Default.SetTextAsync(text).ConfigureAwait(false);
+        CopyCommand?.Execute(content);
+    }
+
+    /// <inheritdoc />
+    public void Cut()
+    {
+        if (!CanCut) return;
+        var content = GetClipboardContent();
+        if (content is string text)
+            Clipboard.Default.SetTextAsync(text).ConfigureAwait(false);
+        if (_entry is not null)
+            _entry.Text = string.Empty;
+        CutCommand?.Execute(content);
+    }
+
+    /// <inheritdoc />
+    public void Paste()
+    {
+        if (!CanPaste) return;
+        var task = Clipboard.Default.GetTextAsync();
+        task.ContinueWith(t =>
+        {
+            if (t.Result is string text && _entry is not null)
+                MainThread.BeginInvokeOnMainThread(() => _entry.Text = text);
+        }, TaskScheduler.Default);
+        PasteCommand?.Execute(null);
+    }
+
+    /// <inheritdoc />
+    public object? GetClipboardContent() => _entry?.Text;
 
     #endregion
 
@@ -1058,6 +1157,9 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
             "PageDown" => HandleLargeDecrementKey(),
             "Home" => HandleHomeKey(),
             "End" => HandleEndKey(),
+            "C" when e.IsPlatformCommandPressed => HandleCopyKey(),
+            "X" when e.IsPlatformCommandPressed => HandleCutKey(),
+            "V" when e.IsPlatformCommandPressed => HandlePasteKey(),
             _ => false
         };
     }
@@ -1075,6 +1177,9 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
                 new Base.KeyboardShortcut { Key = "PageDown", Description = "Decrement by large step (10x)", Category = "Value" },
                 new Base.KeyboardShortcut { Key = "Home", Description = "Set to minimum value", Category = "Value" },
                 new Base.KeyboardShortcut { Key = "End", Description = "Set to maximum value", Category = "Value" },
+                new Base.KeyboardShortcut { Key = "Ctrl+C", Description = "Copy", Category = "Clipboard" },
+                new Base.KeyboardShortcut { Key = "Ctrl+X", Description = "Cut", Category = "Clipboard" },
+                new Base.KeyboardShortcut { Key = "Ctrl+V", Description = "Paste", Category = "Clipboard" },
             });
         }
         return _keyboardShortcuts;
@@ -1139,6 +1244,10 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
         }
         return false;
     }
+
+    private bool HandleCopyKey() { Copy(); return CanCopy; }
+    private bool HandleCutKey() { Cut(); return CanCut; }
+    private bool HandlePasteKey() { Paste(); return CanPaste; }
 
     #endregion
 }


### PR DESCRIPTION
## Summary
- Implements `IClipboardSupport` on ComboBox, MultiSelectComboBox, MaskedEntry, and NumericUpDown
- Adds `CopyCommand`, `CutCommand`, `PasteCommand` bindable properties (MVVM support)
- Adds `CanCopy`, `CanCut`, `CanPaste` state properties
- Adds `Copy()`, `Cut()`, `Paste()`, `GetClipboardContent()` programmatic API
- Registers Ctrl+C/X/V keyboard shortcuts on all 4 controls
- NumericUpDown respects `IsReadOnly` for `CanCut`/`CanPaste`

## Test plan
- [x] `dotnet build` — library compiles (0 warnings, 0 errors, all 4 TFMs)
- [x] `dotnet test` — 346 tests pass
- [x] `dotnet build` on DemoApp — compiles (0 warnings, 0 errors)
- [ ] Manual: Ctrl+C/X/V in ComboBox search field on Windows
- [ ] Manual: Ctrl+C/X/V in MaskedEntry on Windows
- [ ] Manual: Ctrl+C/X/V in NumericUpDown on Windows (also verify IsReadOnly blocks Cut/Paste)
- [ ] Manual: Ctrl+C/X/V in MultiSelectComboBox search field on Windows

Closes #163