### PR TITLE
fix(Clipboard): bridge mobile native clipboard to IClipboardSupport commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Clipboard**: Mobile clipboard bridge to fire `IClipboardSupport` commands when users perform Copy/Cut/Paste via native context menus on Android and iOS (#189)
+  - Android: Intercepts `ActionMode` callbacks on `AppCompatEditText` to detect clipboard actions
+  - iOS/Mac Catalyst: Observes `UIPasteboard.ChangedNotification` and text changes to detect operations
+  - Affected controls: ComboBox, MultiSelectComboBox, MaskedEntry, NumericUpDown
+
 ### Added
 
 - **DataGrid**: `IContextMenuSupport` interface implementation on DataGridView (#162)

--- a/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using MauiControlsExtras.Base;
 using MauiControlsExtras.Base.Validation;
 using MauiControlsExtras.Converters;
+using MauiControlsExtras.Helpers;
 using Microsoft.Maui.Controls.Shapes;
 
 namespace MauiControlsExtras.Controls;
@@ -804,6 +805,8 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
             textBox.PreviewKeyDown += OnWindowsTextBoxPreviewKeyDown;
         }
 #endif
+
+        MobileClipboardBridge.Setup(searchEntry, this);
     }
 
     private void OnKeyboardCaptureEntryHandlerChanged(object? sender, EventArgs e)

--- a/src/MauiControlsExtras/Controls/MaskedEntry.xaml.cs
+++ b/src/MauiControlsExtras/Controls/MaskedEntry.xaml.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Windows.Input;
 using MauiControlsExtras.Base;
 using MauiControlsExtras.Base.Validation;
+using MauiControlsExtras.Helpers;
 
 namespace MauiControlsExtras.Controls;
 
@@ -461,6 +462,17 @@ public partial class MaskedEntry : TextStyledControlBase, IValidatable, Base.IKe
     {
         InitializeComponent();
         ParseMask();
+        entry.HandlerChanged += OnEntryHandlerChanged;
+    }
+
+    #endregion
+
+    #region Handler Changed
+
+    private void OnEntryHandlerChanged(object? sender, EventArgs e)
+    {
+        if (entry.Handler?.PlatformView == null) return;
+        MobileClipboardBridge.Setup(entry, this);
     }
 
     #endregion

--- a/src/MauiControlsExtras/Controls/MultiSelectComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/MultiSelectComboBox.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using MauiControlsExtras.Base;
 using MauiControlsExtras.Base.Validation;
 using MauiControlsExtras.Converters;
+using MauiControlsExtras.Helpers;
 using Microsoft.Maui.Controls.Shapes;
 
 namespace MauiControlsExtras.Controls;
@@ -562,6 +563,8 @@ public partial class MultiSelectComboBox : TextStyledControlBase, IValidatable, 
             textBox.KeyDown += OnWindowsTextBoxKeyDown;
         }
 #endif
+
+        MobileClipboardBridge.Setup(searchEntry, this);
     }
 
 #if WINDOWS

--- a/src/MauiControlsExtras/Controls/NumericUpDown.xaml.cs
+++ b/src/MauiControlsExtras/Controls/NumericUpDown.xaml.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Windows.Input;
 using MauiControlsExtras.Base;
 using MauiControlsExtras.Base.Validation;
+using MauiControlsExtras.Helpers;
 
 namespace MauiControlsExtras.Controls;
 
@@ -741,6 +742,7 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
         _entry.TextChanged += OnEntryTextChanged;
         _entry.Unfocused += OnEntryUnfocused;
         _entry.Focused += OnEntryFocused;
+        _entry.HandlerChanged += OnEntryHandlerChanged;
 
         // Create buttons
         _incrementButton = CreateButton("▲", OnIncrementClicked, OnIncrementPressed, OnButtonReleased);
@@ -970,6 +972,16 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
         {
             // Expected when button released
         }
+    }
+
+    #endregion
+
+    #region Entry Handler Changed
+
+    private void OnEntryHandlerChanged(object? sender, EventArgs e)
+    {
+        if (_entry?.Handler?.PlatformView == null) return;
+        MobileClipboardBridge.Setup(_entry, this);
     }
 
     #endregion

--- a/src/MauiControlsExtras/Helpers/MobileClipboardBridge.cs
+++ b/src/MauiControlsExtras/Helpers/MobileClipboardBridge.cs
@@ -35,7 +35,8 @@ internal static class MobileClipboardBridge
 
         var callback = new ClipboardActionModeCallback(owner);
         editText.CustomSelectionActionModeCallback = callback;
-        editText.CustomInsertionActionModeCallback = callback;
+        if (OperatingSystem.IsAndroidVersionAtLeast(23))
+            editText.CustomInsertionActionModeCallback = callback;
     }
 
     private sealed class ClipboardActionModeCallback : Java.Lang.Object, Android.Views.ActionMode.ICallback


### PR DESCRIPTION
## Summary
Closes #189

On mobile platforms, native context menus (Android EditText action mode, iOS UITextField responder actions) perform clipboard operations directly on the native view, **bypassing IClipboardSupport MVVM commands entirely**. This fix adds a `MobileClipboardBridge` helper that detects native clipboard operations and fires the corresponding commands as notifications.

- **Android**: `ActionMode.ICallback` on `AppCompatEditText` intercepts standard clipboard action IDs and fires `CopyCommand`/`CutCommand`/`PasteCommand`
- **iOS/Mac Catalyst**: `UIPasteboard.ChangedNotification` + text-change heuristic detects Copy/Cut/Paste
- Wired into **ComboBox**, **MultiSelectComboBox**, **MaskedEntry**, **NumericUpDown**
- Native clipboard behavior is preserved (bridge fires commands only, does not duplicate operations)

## Test plan
- [ ] Android: Long-press text → Copy from action bar → CopyCommand fires
- [ ] Android: Long-press text → Cut from action bar → CutCommand fires
- [ ] Android: Long-press empty field → Paste from action bar → PasteCommand fires
- [ ] iOS: Double-tap text → Copy from callout → CopyCommand fires
- [ ] iOS: Double-tap text → Cut from callout → CutCommand fires
- [ ] iOS: Tap field → Paste from callout → PasteCommand fires
- [ ] Desktop: Ctrl+C/X/V still works as before (no regression)
- [x] `dotnet build` — 0 warnings, 0 errors (all 4 TFMs)
- [x] `dotnet build` DemoApp — success
- [x] `dotnet test` — 354/354 passing