### PR TITLE
feat(DataGrid): implement IValidatable interface

### DIFF
--- a/tests/MauiControlsExtras.Tests/Controls/DataGridColumnTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/DataGridColumnTests.cs
@@ -136,4 +136,35 @@ public class DataGridColumnTests
 
         Assert.NotNull(col.ValidationFunc);
     }
+
+    [Fact]
+    public void Validate_WithNoValidationFunc_ReturnsSuccess()
+    {
+        var col = new DataGridTextColumn();
+        var item = new { Name = "Test" };
+
+        var result = col.Validate(item, "some value");
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_WithValidationFunc_DelegatesToFunc()
+    {
+        var col = new DataGridTextColumn();
+        col.ValidationFunc = (item, value) =>
+            string.IsNullOrEmpty(value?.ToString())
+                ? MauiControlsExtras.Base.Validation.ValidationResult.Failure("Required")
+                : MauiControlsExtras.Base.Validation.ValidationResult.Success;
+
+        var item = new { Name = "Test" };
+
+        var successResult = col.Validate(item, "valid");
+        Assert.True(successResult.IsValid);
+
+        var failResult = col.Validate(item, "");
+        Assert.False(failResult.IsValid);
+        Assert.Equal("Required", failResult.FirstError);
+    }
 }

--- a/tests/MauiControlsExtras.Tests/Controls/EventArgsTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/EventArgsTests.cs
@@ -272,6 +272,42 @@ public class EventArgsTests
     }
 
     [Fact]
+    public void DataGridCellValidationEventArgs_StoresProperties()
+    {
+        var column = new DataGridTextColumn { Header = "Name" };
+        var item = new { Name = "Test" };
+        var args = new DataGridCellValidationEventArgs(item, column, "old", "new");
+
+        Assert.Same(item, args.Item);
+        Assert.Same(column, args.Column);
+        Assert.Equal("old", args.OldValue);
+        Assert.Equal("new", args.NewValue);
+    }
+
+    [Fact]
+    public void DataGridCellValidationEventArgs_IsValid_DefaultTrue()
+    {
+        var column = new DataGridTextColumn();
+        var args = new DataGridCellValidationEventArgs(new object(), column, null, null);
+
+        Assert.True(args.IsValid);
+        Assert.Null(args.ErrorMessage);
+    }
+
+    [Fact]
+    public void DataGridCellValidationEventArgs_CanSetInvalid()
+    {
+        var column = new DataGridTextColumn();
+        var args = new DataGridCellValidationEventArgs(new object(), column, null, null);
+
+        args.IsValid = false;
+        args.ErrorMessage = "Value is required";
+
+        Assert.False(args.IsValid);
+        Assert.Equal("Value is required", args.ErrorMessage);
+    }
+
+    [Fact]
     public void DataGridContextMenuOpeningEventArgs_Cancel()
     {
         var args = new DataGridContextMenuOpeningEventArgs(


### PR DESCRIPTION
## Summary
Closes #166

- Implement `IValidatable` on `DataGridView` with `IsValid`, `ValidationErrors`, `Validate()`, and `ValidateCommand`
- Add `IsRequired` / `RequiredErrorMessage` properties (grid must have at least one data row)
- Rename internal `_validationErrors` → `_cellValidationErrors`; new `_gridValidationErrors` flattens cell errors into human-readable strings (`"Row N, Column: error"`)
- Wire `UpdateGridValidationState()` into `CommitEditInternal` and `ItemsSource` changes to keep grid-level state in sync automatically
- Fix cell error indicator to use `EffectiveErrorBorderColor` instead of hardcoded `Colors.Red`
- Add `ValidationChanged` event for state-change notification

## Test plan
- [x] Library builds with 0 errors/warnings
- [x] Demo app builds with 0 errors/warnings
- [x] All 359 tests pass (5 new: 3 EventArgs + 2 column Validate)
- [ ] Manual: existing cell editing/validation behavior unchanged
- [ ] Manual: error indicator respects themed `ErrorBorderColor`