### PR TITLE
feat(Hover): add HoverBehavior for desktop hover feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Hover**: Reusable `HoverBehavior` for desktop hover feedback via `PointerGestureRecognizer` (#171)
+  - Applied to NumericUpDown buttons, BindingNavigator buttons, Calendar navigation and day cells, Rating icons
+  - Theme-aware: defaults to `ControlsTheme.HoverColor`, overridable per-instance
+  - No-op on touch-only platforms (Android/iOS)
 - **ComboBox**: `IContextMenuSupport` interface with long-press and right-click context menus (#176)
 - **MultiSelectComboBox**: `IContextMenuSupport` interface with long-press and right-click context menus (#176)
 - **DataGrid**: `IContextMenuSupport` interface implementation on DataGridView (#162)

--- a/src/MauiControlsExtras/Behaviors/HoverBehavior.cs
+++ b/src/MauiControlsExtras/Behaviors/HoverBehavior.cs
@@ -1,0 +1,104 @@
+using MauiControlsExtras.Theming;
+
+namespace MauiControlsExtras.Behaviors;
+
+/// <summary>
+/// A behavior that provides hover feedback on desktop platforms (Windows/macOS).
+/// Attach this behavior to any View to show a subtle background highlight on pointer hover.
+/// Uses <see cref="PointerGestureRecognizer"/> which is a no-op on touch-only platforms.
+/// </summary>
+public class HoverBehavior : Behavior<View>
+{
+    private View? _attachedView;
+    private PointerGestureRecognizer? _recognizer;
+    private Color? _originalBackgroundColor;
+
+    #region Bindable Properties
+
+    /// <summary>
+    /// Identifies the <see cref="HoverColor"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty HoverColorProperty =
+        BindableProperty.Create(
+            nameof(HoverColor),
+            typeof(Color),
+            typeof(HoverBehavior),
+            null);
+
+    /// <summary>
+    /// Gets or sets the color to apply on hover.
+    /// When null, falls back to <see cref="MauiControlsExtrasTheme.Current"/>.<see cref="ControlsTheme.HoverColor"/>.
+    /// </summary>
+    public Color? HoverColor
+    {
+        get => (Color?)GetValue(HoverColorProperty);
+        set => SetValue(HoverColorProperty, value);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Gets the effective hover color, resolving the theme fallback.
+    /// </summary>
+    private Color EffectiveHoverColor =>
+        HoverColor ?? MauiControlsExtrasTheme.Current.HoverColor;
+
+    /// <inheritdoc/>
+    protected override void OnAttachedTo(View bindable)
+    {
+        base.OnAttachedTo(bindable);
+        _attachedView = bindable;
+
+        _recognizer = new PointerGestureRecognizer();
+        _recognizer.PointerEntered += OnPointerEntered;
+        _recognizer.PointerExited += OnPointerExited;
+        bindable.GestureRecognizers.Add(_recognizer);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDetachingFrom(View bindable)
+    {
+        if (_recognizer != null)
+        {
+            _recognizer.PointerEntered -= OnPointerEntered;
+            _recognizer.PointerExited -= OnPointerExited;
+            bindable.GestureRecognizers.Remove(_recognizer);
+            _recognizer = null;
+        }
+
+        _originalBackgroundColor = null;
+        _attachedView = null;
+        base.OnDetachingFrom(bindable);
+    }
+
+    private void OnPointerEntered(object? sender, PointerEventArgs e)
+    {
+        if (_attachedView == null) return;
+
+        _originalBackgroundColor = _attachedView.BackgroundColor;
+        _attachedView.BackgroundColor = EffectiveHoverColor;
+    }
+
+    private void OnPointerExited(object? sender, PointerEventArgs e)
+    {
+        if (_attachedView == null) return;
+
+        _attachedView.BackgroundColor = _originalBackgroundColor;
+        _originalBackgroundColor = null;
+    }
+
+    /// <summary>
+    /// Convenience method to apply a <see cref="HoverBehavior"/> to a view in a single call.
+    /// </summary>
+    /// <param name="view">The view to attach hover feedback to.</param>
+    /// <param name="hoverColor">Optional custom hover color. When null, uses theme default.</param>
+    public static void Apply(View view, Color? hoverColor = null)
+    {
+        var behavior = new HoverBehavior();
+        if (hoverColor != null)
+        {
+            behavior.HoverColor = hoverColor;
+        }
+        view.Behaviors.Add(behavior);
+    }
+}

--- a/src/MauiControlsExtras/Controls/BindingNavigator/BindingNavigator.xaml.cs
+++ b/src/MauiControlsExtras/Controls/BindingNavigator/BindingNavigator.xaml.cs
@@ -847,7 +847,21 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
     public BindingNavigator()
     {
         InitializeComponent();
+        ApplyHoverBehaviors();
         UpdateButtonStates();
+    }
+
+    private void ApplyHoverBehaviors()
+    {
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(firstButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(previousButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(nextButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(lastButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(addButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(deleteButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(saveButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(cancelButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(refreshButton);
     }
 
     #endregion

--- a/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml.cs
@@ -822,6 +822,8 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
     public Calendar()
     {
         InitializeComponent();
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(previousButton);
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(nextButton);
         _displayDate = DateTime.Today;
         _currentDisplayMode = CalendarDisplayMode.Month;
         BlackoutDates.CollectionChanged += (s, e) => RebuildCalendar();
@@ -1228,6 +1230,11 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
                 SelectDate(capturedDate);
             };
             container.GestureRecognizers.Add(tapGesture);
+        }
+
+        if (isEnabled)
+        {
+            MauiControlsExtras.Behaviors.HoverBehavior.Apply(container);
         }
 
         return container;

--- a/src/MauiControlsExtras/Controls/NumericUpDown.xaml.cs
+++ b/src/MauiControlsExtras/Controls/NumericUpDown.xaml.cs
@@ -869,6 +869,7 @@ public partial class NumericUpDown : TextStyledControlBase, IValidatable, Base.I
         button.Clicked += clicked;
         button.Pressed += pressed;
         button.Released += released;
+        MauiControlsExtras.Behaviors.HoverBehavior.Apply(button);
         return button;
     }
 

--- a/src/MauiControlsExtras/Controls/Rating.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Rating.xaml.cs
@@ -603,6 +603,7 @@ public partial class Rating : StyledControlBase, IValidatable, Base.IKeyboardNav
             var tapGesture = new TapGestureRecognizer();
             tapGesture.Tapped += (s, e) => OnIconTapped(index, e);
             grid.GestureRecognizers.Add(tapGesture);
+            MauiControlsExtras.Behaviors.HoverBehavior.Apply(grid);
         }
 
         return grid;

--- a/tests/MauiControlsExtras.Tests/Behaviors/HoverBehaviorTests.cs
+++ b/tests/MauiControlsExtras.Tests/Behaviors/HoverBehaviorTests.cs
@@ -1,0 +1,82 @@
+using MauiControlsExtras.Behaviors;
+using MauiControlsExtras.Tests.Helpers;
+using MauiControlsExtras.Theming;
+
+namespace MauiControlsExtras.Tests.Behaviors;
+
+public class HoverBehaviorTests : ThemeTestBase
+{
+    [Fact]
+    public void HoverColor_Default_IsNull()
+    {
+        var behavior = new HoverBehavior();
+        Assert.Null(behavior.HoverColor);
+    }
+
+    [Fact]
+    public void HoverColor_CanBeSet()
+    {
+        var behavior = new HoverBehavior();
+        behavior.HoverColor = Colors.Red;
+        Assert.Equal(Colors.Red, behavior.HoverColor);
+    }
+
+    [Fact]
+    public void OnAttachedTo_AddsPointerGestureRecognizer()
+    {
+        var view = new BoxView();
+        var behavior = new HoverBehavior();
+
+        view.Behaviors.Add(behavior);
+
+        Assert.Single(view.GestureRecognizers);
+        Assert.IsType<PointerGestureRecognizer>(view.GestureRecognizers[0]);
+    }
+
+    [Fact]
+    public void OnDetachingFrom_RemovesPointerGestureRecognizer()
+    {
+        var view = new BoxView();
+        var behavior = new HoverBehavior();
+
+        view.Behaviors.Add(behavior);
+        Assert.Single(view.GestureRecognizers);
+
+        view.Behaviors.Remove(behavior);
+        Assert.Empty(view.GestureRecognizers);
+    }
+
+    [Fact]
+    public void Apply_AddsBehaviorToView()
+    {
+        var view = new BoxView();
+
+        HoverBehavior.Apply(view);
+
+        Assert.Single(view.Behaviors);
+        Assert.IsType<HoverBehavior>(view.Behaviors[0]);
+    }
+
+    [Fact]
+    public void Apply_WithCustomColor_SetsBehaviorHoverColor()
+    {
+        var view = new BoxView();
+        var customColor = Colors.Green;
+
+        HoverBehavior.Apply(view, customColor);
+
+        var behavior = Assert.IsType<HoverBehavior>(view.Behaviors[0]);
+        Assert.Equal(customColor, behavior.HoverColor);
+    }
+
+    [Fact]
+    public void Apply_WithNullColor_LeavesHoverColorNull()
+    {
+        var view = new BoxView();
+
+        HoverBehavior.Apply(view);
+
+        var behavior = Assert.IsType<HoverBehavior>(view.Behaviors[0]);
+        Assert.Null(behavior.HoverColor);
+    }
+}

--- a/tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj
+++ b/tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj
@@ -102,6 +102,7 @@
 
     <!-- Behaviors (needed by IKeyboardNavigable) -->
     <Compile Include="..\..\src\MauiControlsExtras\Behaviors\KeyboardBehavior.cs" Link="Linked\Behaviors\KeyboardBehavior.cs" />
+    <Compile Include="..\..\src\MauiControlsExtras\Behaviors\HoverBehavior.cs" Link="Linked\Behaviors\HoverBehavior.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Closes #171

- Add reusable `HoverBehavior : Behavior<View>` using `PointerGestureRecognizer` for subtle background highlight on pointer hover (desktop-only, no-op on touch)
- Applied to NumericUpDown buttons, BindingNavigator buttons (9), Calendar nav arrows + day cells, Rating star icons
- Theme-aware: defaults to `ControlsTheme.HoverColor`, overridable per-instance via `HoverColor` bindable property

## Test plan

- [x] `dotnet build` library — 0 errors, 0 warnings
- [x] `dotnet build` demo app — 0 errors, 0 warnings
- [x] `dotnet test` — 366 passed, 0 failed (7 new HoverBehavior tests)
- [ ] Manual: On Windows/macOS, hover over NumericUpDown +/- buttons, BindingNavigator toolbar buttons, Calendar nav arrows and day cells, Rating stars — all show subtle blue highlight