### PR TITLE
feat(Android): back button closes open dropdowns/popups (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Android Back Button**: Back button now closes open ComboBox/MultiSelectComboBox dropdowns and context menus (#175)
+  - Stack-based (LIFO) handling supports nested popups — most recently opened closes first
+  - No impact on other platforms; Escape key behavior unchanged
 - **Hover**: Reusable `HoverBehavior` for desktop hover feedback via `PointerGestureRecognizer` (#171)
   - Applied to NumericUpDown buttons, BindingNavigator buttons, Calendar navigation and day cells, Rating icons
   - Theme-aware: defaults to `ControlsTheme.HoverColor`, overridable per-instance

--- a/src/MauiControlsExtras/ContextMenu/ContextMenuService.cs
+++ b/src/MauiControlsExtras/ContextMenu/ContextMenuService.cs
@@ -1,3 +1,5 @@
+using MauiControlsExtras.Helpers;
+
 namespace MauiControlsExtras.ContextMenu;
 
 /// <summary>
@@ -434,11 +436,13 @@ public class ContextMenuService : IContextMenuService
 
             _activePopupMenu = popupMenu;
             popupMenu.Show();
+            AndroidBackButtonHandler.Register(this, DismissAndroidMenu);
         });
     }
 
     private void DismissAndroidMenu()
     {
+        AndroidBackButtonHandler.Unregister(this);
         _activePopupMenu?.Dismiss();
         _activePopupMenu = null;
     }

--- a/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
@@ -1609,6 +1609,9 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
             _highlightedIndex = FilteredItems.Count > 0 ? 0 : -1;
             UpdateHighlightVisual();
             RaiseOpened();
+#if ANDROID
+            AndroidBackButtonHandler.Register(this, Close);
+#endif
 
             // Focus the appropriate element when dropdown opens
             if (IsSearchVisible)
@@ -1629,6 +1632,9 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
             collapsedBorder.Stroke = defaultStroke;
             searchEntry.Text = string.Empty;
             searchEntry.Unfocus();
+#if ANDROID
+            AndroidBackButtonHandler.Unregister(this);
+#endif
             RaiseClosed();
         }
     }

--- a/src/MauiControlsExtras/Controls/MultiSelectComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/MultiSelectComboBox.xaml.cs
@@ -1154,6 +1154,9 @@ public partial class MultiSelectComboBox : TextStyledControlBase, IValidatable, 
             UpdateCheckboxStates();
             UpdateSelectAllState();
             RaiseOpened();
+#if ANDROID
+            AndroidBackButtonHandler.Register(this, Close);
+#endif
 
             // Focus the search entry when dropdown opens
             if (IsSearchable)
@@ -1169,6 +1172,9 @@ public partial class MultiSelectComboBox : TextStyledControlBase, IValidatable, 
             collapsedBorder.Stroke = EffectiveBorderColor;
             searchEntry.Text = string.Empty;
             searchEntry.Unfocus();
+#if ANDROID
+            AndroidBackButtonHandler.Unregister(this);
+#endif
             RaiseClosed();
             Validate();
         }

--- a/src/MauiControlsExtras/Helpers/AndroidBackButtonHandler.cs
+++ b/src/MauiControlsExtras/Helpers/AndroidBackButtonHandler.cs
@@ -1,0 +1,160 @@
+namespace MauiControlsExtras.Helpers;
+
+/// <summary>
+/// Handles Android back button presses to close open popups/dropdowns.
+/// Uses a stack (LIFO) so the most recently opened popup closes first.
+/// Cross-platform stack logic; only the native callback hookup is Android-specific.
+/// </summary>
+internal static class AndroidBackButtonHandler
+{
+    private static readonly List<RegistrationEntry> _stack = [];
+
+    /// <summary>
+    /// Registers an owner with a close action. When the Android back button is pressed,
+    /// the most recently registered (topmost) entry's close action is invoked.
+    /// </summary>
+    public static void Register(object owner, Action closeAction)
+    {
+        // Remove existing entry for this owner (re-register moves to top)
+        RemoveOwner(owner);
+
+        _stack.Add(new RegistrationEntry(owner, closeAction));
+
+#if ANDROID
+        EnsureCallbackEnabled();
+#endif
+    }
+
+    /// <summary>
+    /// Unregisters an owner. Safe to call even if the owner was never registered or already removed.
+    /// </summary>
+    public static void Unregister(object owner)
+    {
+        RemoveOwner(owner);
+        CleanupStale();
+
+#if ANDROID
+        UpdateCallbackState();
+#endif
+    }
+
+    /// <summary>
+    /// Handles a back button press by popping the topmost entry and invoking its close action.
+    /// Returns true if an entry was handled, false if the stack was empty.
+    /// </summary>
+    internal static bool HandleBackPress()
+    {
+        CleanupStale();
+
+        if (_stack.Count == 0)
+            return false;
+
+        var top = _stack[^1];
+        _stack.RemoveAt(_stack.Count - 1);
+
+        if (top.OwnerRef.TryGetTarget(out _))
+        {
+            top.CloseAction.Invoke();
+        }
+
+#if ANDROID
+        UpdateCallbackState();
+#endif
+
+        return true;
+    }
+
+    /// <summary>
+    /// Removes entries whose owners have been garbage collected.
+    /// </summary>
+    internal static void CleanupStale()
+    {
+        _stack.RemoveAll(e => !e.OwnerRef.TryGetTarget(out _));
+    }
+
+    /// <summary>
+    /// Clears all registrations. Used for testing.
+    /// </summary>
+    internal static void Reset()
+    {
+        _stack.Clear();
+
+#if ANDROID
+        UpdateCallbackState();
+#endif
+    }
+
+    /// <summary>
+    /// Gets the current registration count. Used for testing.
+    /// </summary>
+    internal static int Count => _stack.Count;
+
+    private static void RemoveOwner(object owner)
+    {
+        _stack.RemoveAll(e =>
+        {
+            if (!e.OwnerRef.TryGetTarget(out var target))
+                return true; // also clean up stale entries
+            return ReferenceEquals(target, owner);
+        });
+    }
+
+#if ANDROID
+    private static AndroidX.Activity.OnBackPressedCallback? _callback;
+
+    private static void EnsureCallbackEnabled()
+    {
+        if (_callback != null)
+        {
+            _callback.Enabled = true;
+            return;
+        }
+
+        var activity = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity;
+        if (activity is not AndroidX.Activity.ComponentActivity componentActivity)
+            return;
+
+        _callback = new BackPressedCallback(() =>
+        {
+            HandleBackPress();
+        });
+
+        componentActivity.OnBackPressedDispatcher.AddCallback(componentActivity, _callback);
+    }
+
+    private static void UpdateCallbackState()
+    {
+        if (_callback != null)
+        {
+            _callback.Enabled = _stack.Count > 0;
+        }
+    }
+
+    private sealed class BackPressedCallback : AndroidX.Activity.OnBackPressedCallback
+    {
+        private readonly Action _onBackPressed;
+
+        public BackPressedCallback(Action onBackPressed) : base(enabled: true)
+        {
+            _onBackPressed = onBackPressed;
+        }
+
+        public override void HandleOnBackPressed()
+        {
+            _onBackPressed();
+        }
+    }
+#endif
+
+    private sealed class RegistrationEntry
+    {
+        public WeakReference<object> OwnerRef { get; }
+        public Action CloseAction { get; }
+
+        public RegistrationEntry(object owner, Action closeAction)
+        {
+            OwnerRef = new WeakReference<object>(owner);
+            CloseAction = closeAction;
+        }
+    }
+}

--- a/tests/MauiControlsExtras.Tests/Helpers/AndroidBackButtonHandlerTests.cs
+++ b/tests/MauiControlsExtras.Tests/Helpers/AndroidBackButtonHandlerTests.cs
@@ -1,0 +1,175 @@
+using MauiControlsExtras.Helpers;
+
+namespace MauiControlsExtras.Tests.Helpers;
+
+public class AndroidBackButtonHandlerTests : IDisposable
+{
+    public AndroidBackButtonHandlerTests()
+    {
+        AndroidBackButtonHandler.Reset();
+    }
+
+    public void Dispose()
+    {
+        AndroidBackButtonHandler.Reset();
+    }
+
+    [Fact]
+    public void Register_HandleBackPress_InvokesCloseAction()
+    {
+        var closed = false;
+        var owner = new object();
+
+        AndroidBackButtonHandler.Register(owner, () => closed = true);
+
+        var handled = AndroidBackButtonHandler.HandleBackPress();
+
+        Assert.True(handled);
+        Assert.True(closed);
+    }
+
+    [Fact]
+    public void HandleBackPress_EmptyStack_ReturnsFalse()
+    {
+        var handled = AndroidBackButtonHandler.HandleBackPress();
+
+        Assert.False(handled);
+    }
+
+    [Fact]
+    public void HandleBackPress_LIFO_MostRecentFirst()
+    {
+        var order = new List<string>();
+        var owner1 = new object();
+        var owner2 = new object();
+        var owner3 = new object();
+
+        AndroidBackButtonHandler.Register(owner1, () => order.Add("first"));
+        AndroidBackButtonHandler.Register(owner2, () => order.Add("second"));
+        AndroidBackButtonHandler.Register(owner3, () => order.Add("third"));
+
+        AndroidBackButtonHandler.HandleBackPress();
+        AndroidBackButtonHandler.HandleBackPress();
+        AndroidBackButtonHandler.HandleBackPress();
+
+        Assert.Equal(["third", "second", "first"], order);
+    }
+
+    [Fact]
+    public void Unregister_RemovesEntry()
+    {
+        var closed = false;
+        var owner = new object();
+
+        AndroidBackButtonHandler.Register(owner, () => closed = true);
+        AndroidBackButtonHandler.Unregister(owner);
+
+        var handled = AndroidBackButtonHandler.HandleBackPress();
+
+        Assert.False(handled);
+        Assert.False(closed);
+    }
+
+    [Fact]
+    public void Unregister_NonExistentOwner_NoThrow()
+    {
+        var owner = new object();
+
+        var exception = Record.Exception(() => AndroidBackButtonHandler.Unregister(owner));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Register_SameOwner_MovesToTop()
+    {
+        var order = new List<string>();
+        var owner1 = new object();
+        var owner2 = new object();
+
+        AndroidBackButtonHandler.Register(owner1, () => order.Add("first"));
+        AndroidBackButtonHandler.Register(owner2, () => order.Add("second"));
+        // Re-register owner1 — should move to top with new action
+        AndroidBackButtonHandler.Register(owner1, () => order.Add("first-again"));
+
+        AndroidBackButtonHandler.HandleBackPress();
+        AndroidBackButtonHandler.HandleBackPress();
+
+        Assert.Equal(["first-again", "second"], order);
+        Assert.Equal(0, AndroidBackButtonHandler.Count);
+    }
+
+    [Fact]
+    public void HandleBackPress_AfterClose_UnregisterIsIdempotent()
+    {
+        // Simulates: back press → Close() → ToggleDropdown() → Unregister()
+        // The entry was already popped by HandleBackPress, so Unregister is a no-op
+        var closeCount = 0;
+        var owner = new object();
+
+        AndroidBackButtonHandler.Register(owner, () =>
+        {
+            closeCount++;
+            // Simulate what Close/ToggleDropdown does: calls Unregister
+            AndroidBackButtonHandler.Unregister(owner);
+        });
+
+        var handled = AndroidBackButtonHandler.HandleBackPress();
+
+        Assert.True(handled);
+        Assert.Equal(1, closeCount);
+        Assert.Equal(0, AndroidBackButtonHandler.Count);
+    }
+
+    [Fact]
+    public void StaleWeakReference_CleanedOnNextOperation()
+    {
+        AndroidBackButtonHandler.Register(new object(), () => { });
+        // The owner is eligible for GC since we didn't keep a reference
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        // CleanupStale happens during HandleBackPress
+        var handled = AndroidBackButtonHandler.HandleBackPress();
+
+        // The stale entry may or may not be collected (GC is non-deterministic),
+        // but it should not throw
+        Assert.Equal(0, AndroidBackButtonHandler.Count);
+    }
+
+    [Fact]
+    public void Reset_ClearsAllRegistrations()
+    {
+        var owner1 = new object();
+        var owner2 = new object();
+
+        AndroidBackButtonHandler.Register(owner1, () => { });
+        AndroidBackButtonHandler.Register(owner2, () => { });
+
+        AndroidBackButtonHandler.Reset();
+
+        Assert.Equal(0, AndroidBackButtonHandler.Count);
+        Assert.False(AndroidBackButtonHandler.HandleBackPress());
+    }
+
+    [Fact]
+    public void MultipleRegistrations_CountIsCorrect()
+    {
+        var owner1 = new object();
+        var owner2 = new object();
+        var owner3 = new object();
+
+        AndroidBackButtonHandler.Register(owner1, () => { });
+        Assert.Equal(1, AndroidBackButtonHandler.Count);
+
+        AndroidBackButtonHandler.Register(owner2, () => { });
+        Assert.Equal(2, AndroidBackButtonHandler.Count);
+
+        AndroidBackButtonHandler.Register(owner3, () => { });
+        Assert.Equal(3, AndroidBackButtonHandler.Count);
+
+        AndroidBackButtonHandler.HandleBackPress();
+        Assert.Equal(2, AndroidBackButtonHandler.Count);
+    }
+}

--- a/tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj
+++ b/tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj
@@ -103,6 +103,9 @@
     <!-- Behaviors (needed by IKeyboardNavigable) -->
     <Compile Include="..\..\src\MauiControlsExtras\Behaviors\KeyboardBehavior.cs" Link="Linked\Behaviors\KeyboardBehavior.cs" />
     <Compile Include="..\..\src\MauiControlsExtras\Behaviors\HoverBehavior.cs" Link="Linked\Behaviors\HoverBehavior.cs" />
+
+    <!-- Helpers -->
+    <Compile Include="..\..\src\MauiControlsExtras\Helpers\AndroidBackButtonHandler.cs" Link="Linked\Helpers\AndroidBackButtonHandler.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Adds `AndroidBackButtonHandler` static helper with LIFO stack to close the most recently opened popup/dropdown when the Android back button is pressed
- Integrates with **ComboBox**, **MultiSelectComboBox**, and **ContextMenuService** — controls register on open, unregister on close
- On Android, registers a single `OnBackPressedCallback` with the activity's `OnBackPressedDispatcher`; on other platforms the handler is a no-op
- Uses `WeakReference<object>` for owners to prevent memory leaks

Closes #175

## Design

- **Stack-based (LIFO)**: Supports nested popups — most recently opened closes first
- **Single callback**: One `OnBackPressedCallback` toggled enabled/disabled as stack grows/shrinks
- **Idempotent**: `HandleBackPress()` pops the entry before invoking `Close()`, so the subsequent `Unregister()` inside `Close()` is a safe no-op
- **Cross-platform testable**: Stack logic has no Android dependencies; only the native callback hookup is behind `#if ANDROID`

## Test plan

- [x] Library builds for all 4 TFMs (android, ios, maccatalyst, windows) — 0 errors, 0 warnings
- [x] Demo app builds — 0 errors
- [x] 376 unit tests pass (10 new `AndroidBackButtonHandlerTests`)
- [ ] Manual: Open ComboBox dropdown → Android back button closes it
- [ ] Manual: Open MultiSelectComboBox → Android back button closes it
- [ ] Manual: Long-press for context menu → Android back button dismisses it
- [ ] Manual: Nested scenario — open combo dropdown → context menu → back closes menu first, then dropdown
- [ ] Manual: Escape key on Windows still works (regression check)