### PR TITLE
Architecture conformance sweep: issues #198-#206

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,9 +89,9 @@ SuccessColor        // Success indication (#388E3C)
 WarningColor        // Warning indication (#F57C00)
 
 // Borders
-CornerRadius        // Rounded corners (default: 8)
+CornerRadius        // Rounded corners (default: 4)
 BorderColor         // Normal border (theme-aware)
-BorderThickness     // Border width (default: 1.5)
+BorderThickness     // Border width (default: 1)
 FocusBorderColor    // Focused state (defaults to AccentColor)
 ErrorBorderColor    // Error state (defaults to ErrorColor)
 DisabledBorderColor // Disabled state
@@ -159,7 +159,6 @@ public class ControlsTheme
     public Color ErrorColor { get; set; }
     public Color SuccessColor { get; set; }
     public Color WarningColor { get; set; }
-    public Color InfoColor { get; set; }
 
     // Surface colors (separate for light/dark)
     public Color SurfaceColor { get; set; }
@@ -581,7 +580,6 @@ All focusable controls MUST define these visual states:
 ```csharp
 // Required focus-related properties (inherited from StyledControlBase)
 FocusBorderColor      // Border color when focused
-FocusBackgroundColor  // Background when focused (optional)
 ```
 
 #### Tab Order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MVVM Command Parity**: Added missing command/command-parameter pairs for user actions that previously had event-only coverage
+  - `Wizard`: `StepChangingCommand`, `FinishingCommand`, `CancellingCommand`
+  - `ComboBox`: `PopupRequestedCommand`
+  - `Calendar`: `DateSelectingCommand`
+  - `PropertyGrid`: `PropertyChangingCommand`
+  - `DataGridView`: `ColumnResizingCommand`, `ExportingCommand`, `ContextMenuItemsOpeningCommand`
+
 ### Fixed
+
+- **Architecture Conformance**: `StyledControlBase` now auto-attaches `KeyboardBehavior` for controls implementing `IKeyboardNavigable`
+  - Ensures keyboard input is wired consistently across interactive controls inheriting styled bases
+  - `DataGridView` now configures the shared behavior (`HandleTabKey = true`) instead of adding a duplicate behavior
+- **Theming Lifecycle**: `StyledControlBase` now safely manages theme event subscription across handler detach/reattach
+- **Theme Notifications**: `AnimatedControlBase` now raises `PropertyChanged` for effective animation properties on theme changes
+- **Base Class Alignment**: `AccordionItem`, `WizardStep`, `ComboBoxPopupContent`, and `DataGridFilterPopup` now inherit from `StyledControlBase`
+- **XAML Convention**: Added `x:Name=\"thisControl\"` to `Accordion` and `Wizard` root elements
+- **PropertyGrid**: Added cancelable pre-change pipeline (`PropertyItem.ValueChanging`) used by `PropertyGrid.PropertyValueChanging`/`PropertyChangingCommand`
+- **Documentation**: Reconciled architecture doc drift (default corner radius/border thickness, removed undocumented `InfoColor`/`FocusBackgroundColor` references)
+- **Demo Docs**: Added Android demo run steps in `README.md` and `docs/quickstart.md`
 
 - **Clipboard**: Mobile clipboard bridge to fire `IClipboardSupport` commands when users perform Copy/Cut/Paste via native context menus on Android and iOS (#189)
   - Android: Intercepts `ActionMode` callbacks on `AppCompatEditText` to detect clipboard actions

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ A comprehensive collection of 16 enterprise-grade UI controls for .NET MAUI appl
 
 ## Demo Application
 
-A complete demo app showcasing all controls is available in [`samples/DemoApp/`](./samples/DemoApp/).
+A complete cross-platform demo app showcasing all controls is available in [`samples/DemoApp/`](./samples/DemoApp/).
+
+Run the demo on Android:
+
+```bash
+dotnet build samples/DemoApp/DemoApp.csproj -f net10.0-android
+dotnet build samples/DemoApp/DemoApp.csproj -t:Run -f net10.0-android
+```
 
 > **Note**: The demo uses direct event handlers for simplicity. For production apps, we recommend proper MVVM patterns with commands and view models.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,5 +39,6 @@ MAUI Controls Extras follows a layered architecture:
 2. **Events have corresponding commands** for MVVM support
 3. **Keyboard/mouse support is mandatory** for desktop platforms
 4. **Theme-aware styling** through `Effective*` properties
+5. **Interactive controls implementing `IKeyboardNavigable` must be wired to keyboard input**
 
 For detailed implementation guidance, see the [Control Development Guide](ControlDevelopmentGuide.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -117,3 +117,12 @@ private void OnCountrySelectionChanged(object sender, object? selectedItem)
 
 - Explore the [ComboBox documentation](controls/combobox.md) for advanced features
 - Check the [API Reference](api/combobox.md) for all available properties and methods
+
+## Run The Demo App (Android)
+
+The sample app in `samples/DemoApp` showcases all controls and runs on Android:
+
+```bash
+dotnet build samples/DemoApp/DemoApp.csproj -f net10.0-android
+dotnet build samples/DemoApp/DemoApp.csproj -t:Run -f net10.0-android
+```

--- a/samples/DemoApp/README.md
+++ b/samples/DemoApp/README.md
@@ -1,0 +1,39 @@
+# DemoApp
+
+`samples/DemoApp` is the official showcase app for MauiControlsExtras.  
+It is a .NET MAUI app that runs on Windows, Android, iOS, and Mac Catalyst.
+
+## Android
+
+Build:
+
+```bash
+dotnet build samples/DemoApp/DemoApp.csproj -f net10.0-android
+```
+
+Run (with an attached emulator/device):
+
+```bash
+dotnet build samples/DemoApp/DemoApp.csproj -t:Run -f net10.0-android
+```
+
+## Included Showcase Pages
+
+The app includes dedicated pages for:
+
+- Accordion
+- BindingNavigator
+- Breadcrumb
+- Calendar
+- ComboBox
+- DataGridView
+- MaskedEntry
+- MultiSelectComboBox
+- NumericUpDown
+- PropertyGrid
+- RangeSlider
+- Rating
+- RichTextEditor
+- TokenEntry
+- TreeView
+- Wizard

--- a/src/MauiControlsExtras/Base/AnimatedControlBase.cs
+++ b/src/MauiControlsExtras/Base/AnimatedControlBase.cs
@@ -101,6 +101,20 @@ public abstract class AnimatedControlBase : StyledControlBase
 
     #endregion
 
+    #region Theme Change
+
+    /// <inheritdoc />
+    public override void OnThemeChanged(AppTheme theme)
+    {
+        base.OnThemeChanged(theme);
+        OnPropertyChanged(nameof(EffectiveAnimationDuration));
+        OnPropertyChanged(nameof(EffectiveAnimationTimeSpan));
+        OnPropertyChanged(nameof(EffectiveAnimationEasing));
+        OnPropertyChanged(nameof(EffectiveEnableAnimations));
+    }
+
+    #endregion
+
     #region Property Changed Handlers
 
     private static void OnAnimationDurationChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/MauiControlsExtras/Base/StyledControlBase.cs
+++ b/src/MauiControlsExtras/Base/StyledControlBase.cs
@@ -1,3 +1,4 @@
+using MauiControlsExtras.Behaviors;
 using MauiControlsExtras.Theming;
 
 namespace MauiControlsExtras.Base;
@@ -8,6 +9,8 @@ namespace MauiControlsExtras.Base;
 /// </summary>
 public abstract class StyledControlBase : ContentView, IThemeAware
 {
+    private bool _isThemeSubscribed;
+
     #region Color Bindable Properties
 
     /// <summary>
@@ -471,7 +474,8 @@ public abstract class StyledControlBase : ContentView, IThemeAware
     /// </summary>
     protected StyledControlBase()
     {
-        MauiControlsExtrasTheme.ThemeChanged += OnGlobalThemeChanged;
+        EnsureThemeSubscription();
+        AttachKeyboardBehaviorIfNeeded();
     }
 
     #endregion
@@ -739,7 +743,12 @@ public abstract class StyledControlBase : ContentView, IThemeAware
 
         if (Handler == null)
         {
-            MauiControlsExtrasTheme.ThemeChanged -= OnGlobalThemeChanged;
+            RemoveThemeSubscription();
+        }
+        else
+        {
+            EnsureThemeSubscription();
+            AttachKeyboardBehaviorIfNeeded();
         }
     }
 
@@ -786,6 +795,47 @@ public abstract class StyledControlBase : ContentView, IThemeAware
             Radius = (float)radius,
             Opacity = (float)opacity
         };
+    }
+
+    #endregion
+
+    #region Private Helpers
+
+    private void EnsureThemeSubscription()
+    {
+        if (_isThemeSubscribed)
+        {
+            return;
+        }
+
+        MauiControlsExtrasTheme.ThemeChanged += OnGlobalThemeChanged;
+        _isThemeSubscribed = true;
+    }
+
+    private void RemoveThemeSubscription()
+    {
+        if (!_isThemeSubscribed)
+        {
+            return;
+        }
+
+        MauiControlsExtrasTheme.ThemeChanged -= OnGlobalThemeChanged;
+        _isThemeSubscribed = false;
+    }
+
+    private void AttachKeyboardBehaviorIfNeeded()
+    {
+        if (this is not IKeyboardNavigable)
+        {
+            return;
+        }
+
+        if (Behaviors.OfType<KeyboardBehavior>().Any())
+        {
+            return;
+        }
+
+        Behaviors.Add(new KeyboardBehavior());
     }
 
     #endregion

--- a/src/MauiControlsExtras/Controls/Accordion/Accordion.xaml
+++ b/src/MauiControlsExtras/Controls/Accordion/Accordion.xaml
@@ -2,6 +2,7 @@
 <base:HeaderedControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                           xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                           xmlns:base="clr-namespace:MauiControlsExtras.Base"
-                          x:Class="MauiControlsExtras.Controls.Accordion">
+                          x:Class="MauiControlsExtras.Controls.Accordion"
+                          x:Name="thisControl">
     <!-- Visual tree is built in code to avoid conflict with [ContentProperty(nameof(Items))] -->
 </base:HeaderedControlBase>

--- a/src/MauiControlsExtras/Controls/Accordion/AccordionItem.cs
+++ b/src/MauiControlsExtras/Controls/Accordion/AccordionItem.cs
@@ -1,3 +1,4 @@
+using MauiControlsExtras.Base;
 using System.Windows.Input;
 
 namespace MauiControlsExtras.Controls;
@@ -5,7 +6,7 @@ namespace MauiControlsExtras.Controls;
 /// <summary>
 /// Represents a single expandable/collapsible item in an Accordion.
 /// </summary>
-public class AccordionItem : ContentView
+public class AccordionItem : StyledControlBase
 {
     #region Bindable Properties
 

--- a/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Calendar/Calendar.xaml.cs
@@ -172,6 +172,22 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         typeof(Calendar));
 
     /// <summary>
+    /// Identifies the <see cref="DateSelectingCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty DateSelectingCommandProperty = BindableProperty.Create(
+        nameof(DateSelectingCommand),
+        typeof(ICommand),
+        typeof(Calendar));
+
+    /// <summary>
+    /// Identifies the <see cref="DateSelectingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty DateSelectingCommandParameterProperty = BindableProperty.Create(
+        nameof(DateSelectingCommandParameter),
+        typeof(object),
+        typeof(Calendar));
+
+    /// <summary>
     /// Identifies the <see cref="GotFocusCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty GotFocusCommandProperty = BindableProperty.Create(
@@ -423,6 +439,25 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
     {
         get => GetValue(DisplayDateChangedCommandParameterProperty);
         set => SetValue(DisplayDateChangedCommandParameterProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command executed before a date is selected.
+    /// </summary>
+    public ICommand? DateSelectingCommand
+    {
+        get => (ICommand?)GetValue(DateSelectingCommandProperty);
+        set => SetValue(DateSelectingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="DateSelectingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? DateSelectingCommandParameter
+    {
+        get => GetValue(DateSelectingCommandParameterProperty);
+        set => SetValue(DateSelectingCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -961,6 +996,10 @@ public partial class Calendar : HeaderedControlBase, IKeyboardNavigable, ISelect
         // Raise selecting event
         var selectingArgs = new CalendarDateSelectingEventArgs(date, true);
         DateSelecting?.Invoke(this, selectingArgs);
+        if (DateSelectingCommand?.CanExecute(selectingArgs) == true)
+        {
+            DateSelectingCommand.Execute(DateSelectingCommandParameter ?? selectingArgs);
+        }
         if (selectingArgs.Cancel) return;
 
         var oldSelection = _selectedDates.ToList();

--- a/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
@@ -295,6 +295,24 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
         default(ICommand));
 
     /// <summary>
+    /// Identifies the <see cref="PopupRequestedCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PopupRequestedCommandProperty = BindableProperty.Create(
+        nameof(PopupRequestedCommand),
+        typeof(ICommand),
+        typeof(ComboBox),
+        default(ICommand));
+
+    /// <summary>
+    /// Identifies the <see cref="PopupRequestedCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PopupRequestedCommandParameterProperty = BindableProperty.Create(
+        nameof(PopupRequestedCommandParameter),
+        typeof(object),
+        typeof(ComboBox),
+        default(object));
+
+    /// <summary>
     /// Identifies the <see cref="ClearCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty ClearCommandProperty = BindableProperty.Create(
@@ -638,6 +656,25 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
     {
         get => (ICommand?)GetValue(ClosedCommandProperty);
         set => SetValue(ClosedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command to execute when popup mode requests an external popup.
+    /// </summary>
+    public ICommand? PopupRequestedCommand
+    {
+        get => (ICommand?)GetValue(PopupRequestedCommandProperty);
+        set => SetValue(PopupRequestedCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="PopupRequestedCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? PopupRequestedCommandParameter
+    {
+        get => GetValue(PopupRequestedCommandParameterProperty);
+        set => SetValue(PopupRequestedCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -1590,6 +1627,10 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
                 Placeholder,
                 IsSearchVisible);
             PopupRequested?.Invoke(this, args);
+            if (PopupRequestedCommand?.CanExecute(args) == true)
+            {
+                PopupRequestedCommand.Execute(PopupRequestedCommandParameter ?? args);
+            }
             return;
         }
 

--- a/src/MauiControlsExtras/Controls/ComboBox/ComboBoxPopupContent.xaml
+++ b/src/MauiControlsExtras/Controls/ComboBox/ComboBoxPopupContent.xaml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiControlsExtras.Controls.ComboBoxPopupContent"
-             x:Name="thisPopup"
-             WidthRequest="250"
-             HeightRequest="280">
+<base:StyledControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                        xmlns:base="clr-namespace:MauiControlsExtras.Base"
+                        x:Class="MauiControlsExtras.Controls.ComboBoxPopupContent"
+                        x:Name="thisPopup"
+                        WidthRequest="250"
+                        HeightRequest="280">
 
     <Border Stroke="{AppThemeBinding Light=#CCCCCC, Dark=#555555}"
             StrokeThickness="1"
@@ -86,4 +87,4 @@
             </CollectionView>
         </Grid>
     </Border>
-</ContentView>
+</base:StyledControlBase>

--- a/src/MauiControlsExtras/Controls/ComboBox/ComboBoxPopupContent.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox/ComboBoxPopupContent.xaml.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.ObjectModel;
+using MauiControlsExtras.Base;
 
 namespace MauiControlsExtras.Controls;
 
@@ -7,7 +8,7 @@ namespace MauiControlsExtras.Controls;
 /// Standalone popup content for ComboBox dropdown with search and list.
 /// Used by DataGridView for ComboBox editing in cells.
 /// </summary>
-public partial class ComboBoxPopupContent : ContentView
+public partial class ComboBoxPopupContent : StyledControlBase
 {
     private readonly ObservableCollection<object> _filteredItems = new();
     private List<object>? _allItems;
@@ -422,7 +423,7 @@ public partial class ComboBoxPopupContent : ContentView
         }
     }
 
-    private void OnItemsListSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    private void OnItemsListSelectionChanged(object? sender, Microsoft.Maui.Controls.SelectionChangedEventArgs e)
     {
         // Ignore programmatic selection changes for highlighting
         if (_isUpdatingHighlight) return;

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridFilterPopup.xaml
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridFilterPopup.xaml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiControlsExtras.Controls.DataGridFilterPopup"
-             x:Name="thisPopup"
-             WidthRequest="280"
-             HeightRequest="350">
+<base:StyledControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                        xmlns:base="clr-namespace:MauiControlsExtras.Base"
+                        x:Class="MauiControlsExtras.Controls.DataGridFilterPopup"
+                        x:Name="thisPopup"
+                        WidthRequest="280"
+                        HeightRequest="350">
 
     <Border Stroke="{AppThemeBinding Light=#CCCCCC, Dark=#444444}"
             StrokeThickness="1"
@@ -85,4 +86,4 @@
             </Grid>
         </Grid>
     </Border>
-</ContentView>
+</base:StyledControlBase>

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridFilterPopup.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridFilterPopup.xaml.cs
@@ -1,9 +1,11 @@
+using MauiControlsExtras.Base;
+
 namespace MauiControlsExtras.Controls;
 
 /// <summary>
 /// A popup for filtering data grid columns.
 /// </summary>
-public partial class DataGridFilterPopup : ContentView
+public partial class DataGridFilterPopup : StyledControlBase
 {
     private readonly HashSet<object> _selectedValues = new();
     private readonly Dictionary<object, CheckBox> _checkboxMap = new();

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -752,6 +752,22 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="ExportingCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ExportingCommandProperty = BindableProperty.Create(
+        nameof(ExportingCommand),
+        typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="ExportingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ExportingCommandParameterProperty = BindableProperty.Create(
+        nameof(ExportingCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="UndoCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty UndoCommandProperty = BindableProperty.Create(
@@ -848,6 +864,22 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         typeof(DataGridView));
 
     /// <summary>
+    /// Identifies the <see cref="ColumnResizingCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ColumnResizingCommandProperty = BindableProperty.Create(
+        nameof(ColumnResizingCommand),
+        typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="ColumnResizingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ColumnResizingCommandParameterProperty = BindableProperty.Create(
+        nameof(ColumnResizingCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
     /// Identifies the <see cref="RowSelectedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty RowSelectedCommandProperty = BindableProperty.Create(
@@ -908,6 +940,22 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     /// </summary>
     public static readonly BindableProperty ClearSelectionCommandParameterProperty = BindableProperty.Create(
         nameof(ClearSelectionCommandParameter),
+        typeof(object),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="ContextMenuItemsOpeningCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ContextMenuItemsOpeningCommandProperty = BindableProperty.Create(
+        nameof(ContextMenuItemsOpeningCommand),
+        typeof(ICommand),
+        typeof(DataGridView));
+
+    /// <summary>
+    /// Identifies the <see cref="ContextMenuItemsOpeningCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty ContextMenuItemsOpeningCommandParameterProperty = BindableProperty.Create(
+        nameof(ContextMenuItemsOpeningCommandParameter),
         typeof(object),
         typeof(DataGridView));
 
@@ -1649,6 +1697,26 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         set => SetValue(ExportCommandParameterProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the command executed before exporting.
+    /// The command parameter is <see cref="DataGridExportEventArgs"/>.
+    /// </summary>
+    public ICommand? ExportingCommand
+    {
+        get => (ICommand?)GetValue(ExportingCommandProperty);
+        set => SetValue(ExportingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ExportingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ExportingCommandParameter
+    {
+        get => GetValue(ExportingCommandParameterProperty);
+        set => SetValue(ExportingCommandParameterProperty, value);
+    }
+
     /// <inheritdoc />
     public ICommand? UndoCommand
     {
@@ -1755,6 +1823,26 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     }
 
     /// <summary>
+    /// Gets or sets the command executed when a column resize starts.
+    /// The command parameter is <see cref="DataGridColumnEventArgs"/>.
+    /// </summary>
+    public ICommand? ColumnResizingCommand
+    {
+        get => (ICommand?)GetValue(ColumnResizingCommandProperty);
+        set => SetValue(ColumnResizingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ColumnResizingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ColumnResizingCommandParameter
+    {
+        get => GetValue(ColumnResizingCommandParameterProperty);
+        set => SetValue(ColumnResizingCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when a row is selected.
     /// The command parameter is <see cref="DataGridRowSelectionEventArgs"/>.
     /// </summary>
@@ -1830,6 +1918,26 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     {
         get => GetValue(ClearSelectionCommandParameterProperty);
         set => SetValue(ClearSelectionCommandParameterProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the command executed before context menu items are shown.
+    /// The command parameter is <see cref="DataGridContextMenuOpeningEventArgs"/>.
+    /// </summary>
+    public ICommand? ContextMenuItemsOpeningCommand
+    {
+        get => (ICommand?)GetValue(ContextMenuItemsOpeningCommandProperty);
+        set => SetValue(ContextMenuItemsOpeningCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="ContextMenuItemsOpeningCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? ContextMenuItemsOpeningCommandParameter
+    {
+        get => GetValue(ContextMenuItemsOpeningCommandParameterProperty);
+        set => SetValue(ContextMenuItemsOpeningCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -2179,8 +2287,13 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
         // Set initial page size picker
         pageSizePicker.SelectedIndex = 2; // 50
 
-        // Attach keyboard behavior for desktop keyboard handling (F2, arrow keys, etc.)
-        Behaviors.Add(new KeyboardBehavior { HandleTabKey = true });
+        // DataGrid handles Tab internally for cell navigation.
+        var keyboardBehavior = Behaviors.OfType<KeyboardBehavior>().FirstOrDefault();
+        if (keyboardBehavior != null)
+        {
+            keyboardBehavior.HandleTabKey = true;
+        }
+
     }
 
     #endregion
@@ -2338,6 +2451,10 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         var args = new DataGridExportEventArgs("CSV", options);
         Exporting?.Invoke(this, args);
+        if (ExportingCommand?.CanExecute(args) == true)
+        {
+            ExportingCommand.Execute(ExportingCommandParameter ?? args);
+        }
 
         if (args.Cancel)
             return string.Empty;
@@ -2376,6 +2493,10 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
         var args = new DataGridExportEventArgs("JSON", options);
         Exporting?.Invoke(this, args);
+        if (ExportingCommand?.CanExecute(args) == true)
+        {
+            ExportingCommand.Execute(ExportingCommandParameter ?? args);
+        }
 
         if (args.Cancel)
             return string.Empty;
@@ -3225,6 +3346,10 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
             this);
 
         ContextMenuItemsOpening?.Invoke(this, newArgs);
+        if (ContextMenuItemsOpeningCommand?.CanExecute(newArgs) == true)
+        {
+            ContextMenuItemsOpeningCommand.Execute(ContextMenuItemsOpeningCommandParameter ?? newArgs);
+        }
 
         // Fire IContextMenuSupport.ContextMenuOpening event (explicit interface event)
         _contextMenuOpeningHandler?.Invoke(this, newArgs);
@@ -5398,6 +5523,10 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
 
                 var args = new DataGridColumnEventArgs(column, columnIndex, _resizeStartWidth, _resizeStartWidth);
                 ColumnResizing?.Invoke(this, args);
+                if (ColumnResizingCommand?.CanExecute(args) == true)
+                {
+                    ColumnResizingCommand.Execute(ColumnResizingCommandParameter ?? args);
+                }
                 break;
 
             case GestureStatus.Running:

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml.cs
@@ -131,6 +131,22 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         typeof(PropertyGrid));
 
     /// <summary>
+    /// Identifies the <see cref="PropertyChangingCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PropertyChangingCommandProperty = BindableProperty.Create(
+        nameof(PropertyChangingCommand),
+        typeof(ICommand),
+        typeof(PropertyGrid));
+
+    /// <summary>
+    /// Identifies the <see cref="PropertyChangingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty PropertyChangingCommandParameterProperty = BindableProperty.Create(
+        nameof(PropertyChangingCommandParameter),
+        typeof(object),
+        typeof(PropertyGrid));
+
+    /// <summary>
     /// Identifies the <see cref="SelectedObjectChangedCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty SelectedObjectChangedCommandProperty = BindableProperty.Create(
@@ -325,6 +341,25 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the command executed before a property value changes.
+    /// </summary>
+    public ICommand? PropertyChangingCommand
+    {
+        get => (ICommand?)GetValue(PropertyChangingCommandProperty);
+        set => SetValue(PropertyChangingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="PropertyChangingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? PropertyChangingCommandParameter
+    {
+        get => GetValue(PropertyChangingCommandParameterProperty);
+        set => SetValue(PropertyChangingCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when the selected object changes.
     /// </summary>
     public ICommand? SelectedObjectChangedCommand
@@ -425,9 +460,7 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
     /// <summary>
     /// Occurs before a property value changes (cancelable).
     /// </summary>
-#pragma warning disable CS0067
     public event EventHandler<PropertyValueChangingEventArgs>? PropertyValueChanging;
-#pragma warning restore CS0067
 
     /// <summary>
     /// Occurs when the selected object changes.
@@ -634,6 +667,7 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
         // Subscribe to property changes
         foreach (var prop in _flatProperties)
         {
+            prop.ValueChanging += OnPropertyValueChanging;
             prop.ValueChanged += OnPropertyValueChanged;
         }
 
@@ -1105,6 +1139,15 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
     #endregion
 
     #region Event Handlers
+
+    private void OnPropertyValueChanging(object? sender, PropertyValueChangingEventArgs e)
+    {
+        PropertyValueChanging?.Invoke(this, e);
+        if (PropertyChangingCommand?.CanExecute(e) == true)
+        {
+            PropertyChangingCommand.Execute(PropertyChangingCommandParameter ?? e);
+        }
+    }
 
     private void OnPropertyValueChanged(object? sender, PropertyValueChangedEventArgs e)
     {

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyItem.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyItem.cs
@@ -94,6 +94,13 @@ public class PropertyItem : INotifyPropertyChanged
             if (!Equals(_value, value))
             {
                 var oldValue = _value;
+                var changingArgs = new PropertyValueChangingEventArgs(this, oldValue, value);
+                ValueChanging?.Invoke(this, changingArgs);
+                if (changingArgs.Cancel)
+                {
+                    return;
+                }
+
                 _value = value;
 
                 // Update the actual property
@@ -163,6 +170,11 @@ public class PropertyItem : INotifyPropertyChanged
             }
         }
     }
+
+    /// <summary>
+    /// Occurs before the property value changes (cancelable).
+    /// </summary>
+    public event EventHandler<PropertyValueChangingEventArgs>? ValueChanging;
 
     /// <summary>
     /// Occurs when the property value changes.

--- a/src/MauiControlsExtras/Controls/Wizard/Wizard.xaml
+++ b/src/MauiControlsExtras/Controls/Wizard/Wizard.xaml
@@ -2,6 +2,7 @@
 <base:NavigationControlBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                             xmlns:base="clr-namespace:MauiControlsExtras.Base"
-                            x:Class="MauiControlsExtras.Controls.Wizard">
+                            x:Class="MauiControlsExtras.Controls.Wizard"
+                            x:Name="thisControl">
     <!-- Visual tree is built in code to avoid conflict with [ContentProperty(nameof(Steps))] -->
 </base:NavigationControlBase>

--- a/src/MauiControlsExtras/Controls/Wizard/Wizard.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Wizard/Wizard.xaml.cs
@@ -241,6 +241,22 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         typeof(Wizard));
 
     /// <summary>
+    /// Identifies the <see cref="StepChangingCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty StepChangingCommandProperty = BindableProperty.Create(
+        nameof(StepChangingCommand),
+        typeof(ICommand),
+        typeof(Wizard));
+
+    /// <summary>
+    /// Identifies the <see cref="StepChangingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty StepChangingCommandParameterProperty = BindableProperty.Create(
+        nameof(StepChangingCommandParameter),
+        typeof(object),
+        typeof(Wizard));
+
+    /// <summary>
     /// Identifies the <see cref="StepValidatingCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty StepValidatingCommandProperty = BindableProperty.Create(
@@ -273,6 +289,22 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         typeof(Wizard));
 
     /// <summary>
+    /// Identifies the <see cref="FinishingCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty FinishingCommandProperty = BindableProperty.Create(
+        nameof(FinishingCommand),
+        typeof(ICommand),
+        typeof(Wizard));
+
+    /// <summary>
+    /// Identifies the <see cref="FinishingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty FinishingCommandParameterProperty = BindableProperty.Create(
+        nameof(FinishingCommandParameter),
+        typeof(object),
+        typeof(Wizard));
+
+    /// <summary>
     /// Identifies the <see cref="CancelledCommand"/> bindable property.
     /// </summary>
     public static readonly BindableProperty CancelledCommandProperty = BindableProperty.Create(
@@ -285,6 +317,22 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
     /// </summary>
     public static readonly BindableProperty CancelledCommandParameterProperty = BindableProperty.Create(
         nameof(CancelledCommandParameter),
+        typeof(object),
+        typeof(Wizard));
+
+    /// <summary>
+    /// Identifies the <see cref="CancellingCommand"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CancellingCommandProperty = BindableProperty.Create(
+        nameof(CancellingCommand),
+        typeof(ICommand),
+        typeof(Wizard));
+
+    /// <summary>
+    /// Identifies the <see cref="CancellingCommandParameter"/> bindable property.
+    /// </summary>
+    public static readonly BindableProperty CancellingCommandParameterProperty = BindableProperty.Create(
+        nameof(CancellingCommandParameter),
         typeof(object),
         typeof(Wizard));
 
@@ -596,6 +644,27 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the cancelable command executed before the step changes.
+    /// The command parameter is <see cref="WizardStepChangingEventArgs"/>.
+    /// Set Cancel = true to prevent navigation.
+    /// </summary>
+    public ICommand? StepChangingCommand
+    {
+        get => (ICommand?)GetValue(StepChangingCommandProperty);
+        set => SetValue(StepChangingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="StepChangingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? StepChangingCommandParameter
+    {
+        get => GetValue(StepChangingCommandParameterProperty);
+        set => SetValue(StepChangingCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the cancelable command executed before step validation.
     /// The command parameter is <see cref="WizardStepValidatingEventArgs"/>.
     /// Set Cancel = true to prevent navigation.
@@ -636,6 +705,27 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
     }
 
     /// <summary>
+    /// Gets or sets the cancelable command executed before the wizard finishes.
+    /// The command parameter is <see cref="WizardFinishingEventArgs"/>.
+    /// Set Cancel = true to prevent finish.
+    /// </summary>
+    public ICommand? FinishingCommand
+    {
+        get => (ICommand?)GetValue(FinishingCommandProperty);
+        set => SetValue(FinishingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="FinishingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? FinishingCommandParameter
+    {
+        get => GetValue(FinishingCommandParameterProperty);
+        set => SetValue(FinishingCommandParameterProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the command executed when the wizard is cancelled.
     /// </summary>
     public ICommand? CancelledCommand
@@ -652,6 +742,27 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
     {
         get => GetValue(CancelledCommandParameterProperty);
         set => SetValue(CancelledCommandParameterProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the cancelable command executed before the wizard is cancelled.
+    /// The command parameter is <see cref="WizardCancellingEventArgs"/>.
+    /// Set Cancel = true to prevent cancellation.
+    /// </summary>
+    public ICommand? CancellingCommand
+    {
+        get => (ICommand?)GetValue(CancellingCommandProperty);
+        set => SetValue(CancellingCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the parameter to pass to <see cref="CancellingCommand"/>.
+    /// If not set, the default event argument is used as the parameter.
+    /// </summary>
+    public object? CancellingCommandParameter
+    {
+        get => GetValue(CancellingCommandParameterProperty);
+        set => SetValue(CancellingCommandParameterProperty, value);
     }
 
     /// <inheritdoc/>
@@ -1162,6 +1273,10 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         // Raise changing event
         var changingArgs = new WizardStepChangingEventArgs(oldStep, newStep, oldIndex, index);
         StepChanging?.Invoke(this, changingArgs);
+        if (StepChangingCommand?.CanExecute(changingArgs) == true)
+        {
+            StepChangingCommand.Execute(StepChangingCommandParameter ?? changingArgs);
+        }
         if (changingArgs.Cancel)
             return false;
 
@@ -1219,6 +1334,10 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         // Raise finishing event
         var finishingArgs = new WizardFinishingEventArgs(_steps.ToList());
         Finishing?.Invoke(this, finishingArgs);
+        if (FinishingCommand?.CanExecute(finishingArgs) == true)
+        {
+            FinishingCommand.Execute(FinishingCommandParameter ?? finishingArgs);
+        }
         if (finishingArgs.Cancel)
             return false;
 
@@ -1245,6 +1364,10 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         // Raise cancelling event
         var cancellingArgs = new WizardCancellingEventArgs(_currentIndex);
         Cancelling?.Invoke(this, cancellingArgs);
+        if (CancellingCommand?.CanExecute(cancellingArgs) == true)
+        {
+            CancellingCommand.Execute(CancellingCommandParameter ?? cancellingArgs);
+        }
         if (cancellingArgs.Cancel)
             return false;
 

--- a/src/MauiControlsExtras/Controls/Wizard/WizardStep.cs
+++ b/src/MauiControlsExtras/Controls/Wizard/WizardStep.cs
@@ -1,12 +1,13 @@
 using System.ComponentModel;
 using System.Windows.Input;
+using MauiControlsExtras.Base;
 
 namespace MauiControlsExtras.Controls;
 
 /// <summary>
 /// Represents a single step in a Wizard control.
 /// </summary>
-public class WizardStep : ContentView, INotifyPropertyChanged
+public class WizardStep : StyledControlBase, INotifyPropertyChanged
 {
     #region Private Fields
 

--- a/tests/MauiControlsExtras.Tests/Base/AnimatedControlBaseTests.cs
+++ b/tests/MauiControlsExtras.Tests/Base/AnimatedControlBaseTests.cs
@@ -171,5 +171,25 @@ public class AnimatedControlBaseTests : ThemeTestBase
         Assert.Equal(500, control.EffectiveAnimationDuration);
     }
 
+    [Fact]
+    public void ThemeChanged_NotifiesAllEffectiveAnimationProperties()
+    {
+        var control = new TestableAnimatedControl();
+        var changed = new List<string>();
+        control.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        MauiControlsExtrasTheme.ModifyCurrentTheme(t =>
+        {
+            t.AnimationDuration = 175;
+            t.EnableAnimations = false;
+            t.AnimationEasing = Easing.Linear;
+        });
+
+        Assert.Contains(nameof(AnimatedControlBase.EffectiveAnimationDuration), changed);
+        Assert.Contains(nameof(AnimatedControlBase.EffectiveAnimationTimeSpan), changed);
+        Assert.Contains(nameof(AnimatedControlBase.EffectiveAnimationEasing), changed);
+        Assert.Contains(nameof(AnimatedControlBase.EffectiveEnableAnimations), changed);
+    }
+
     #endregion
 }

--- a/tests/MauiControlsExtras.Tests/Base/StyledControlBaseTests.cs
+++ b/tests/MauiControlsExtras.Tests/Base/StyledControlBaseTests.cs
@@ -1,4 +1,5 @@
 using MauiControlsExtras.Base;
+using MauiControlsExtras.Behaviors;
 using MauiControlsExtras.Tests.Helpers;
 using MauiControlsExtras.Theming;
 
@@ -368,6 +369,24 @@ public class StyledControlBaseTests : ThemeTestBase
         MauiControlsExtrasTheme.ApplyModernTheme();
 
         Assert.Equal(Colors.Red, control.EffectiveAccentColor);
+    }
+
+    #endregion
+
+    #region Keyboard Behavior Attachment
+
+    [Fact]
+    public void StyledControl_WithoutIKeyboardNavigable_DoesNotAttachKeyboardBehavior()
+    {
+        var control = new TestableStyledControl();
+        Assert.DoesNotContain(control.Behaviors, b => b is KeyboardBehavior);
+    }
+
+    [Fact]
+    public void StyledControl_WithIKeyboardNavigable_AttachesKeyboardBehavior()
+    {
+        var control = new TestableKeyboardNavigableStyledControl();
+        Assert.Single(control.Behaviors.OfType<KeyboardBehavior>());
     }
 
     #endregion

--- a/tests/MauiControlsExtras.Tests/Controls/PropertyItemTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/PropertyItemTests.cs
@@ -106,6 +106,34 @@ public class PropertyItemTests
     }
 
     [Fact]
+    public void Value_Set_RaisesValueChangingEvent()
+    {
+        var target = new SampleObject { Name = "Old" };
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+        PropertyValueChangingEventArgs? args = null;
+        item.ValueChanging += (_, e) => args = e;
+
+        item.Value = "New";
+
+        Assert.NotNull(args);
+        Assert.Equal("Old", args.CurrentValue);
+        Assert.Equal("New", args.NewValue);
+    }
+
+    [Fact]
+    public void Value_Set_WhenValueChangingCancelled_DoesNotUpdateValue()
+    {
+        var target = new SampleObject { Name = "Old" };
+        var item = CreatePropertyItem(target, nameof(SampleObject.Name));
+        item.ValueChanging += (_, e) => e.Cancel = true;
+
+        item.Value = "New";
+
+        Assert.Equal("Old", item.Value);
+        Assert.Equal("Old", target.Name);
+    }
+
+    [Fact]
     public void Value_Set_RaisesPropertyChanged()
     {
         var target = new SampleObject { Name = "Old" };

--- a/tests/MauiControlsExtras.Tests/Helpers/TestableKeyboardNavigableStyledControl.cs
+++ b/tests/MauiControlsExtras.Tests/Helpers/TestableKeyboardNavigableStyledControl.cs
@@ -1,0 +1,45 @@
+using System.Windows.Input;
+using MauiControlsExtras.Base;
+
+namespace MauiControlsExtras.Tests.Helpers;
+
+/// <summary>
+/// Concrete styled control that implements <see cref="IKeyboardNavigable"/> for keyboard behavior tests.
+/// </summary>
+public class TestableKeyboardNavigableStyledControl : StyledControlBase, IKeyboardNavigable
+{
+    public bool CanReceiveFocus => true;
+
+    public bool IsKeyboardNavigationEnabled { get; set; } = true;
+
+    public bool HasKeyboardFocus { get; private set; }
+
+    public ICommand? GotFocusCommand { get; set; }
+
+    public ICommand? LostFocusCommand { get; set; }
+
+    public ICommand? KeyPressCommand { get; set; }
+
+    public event EventHandler<KeyboardFocusEventArgs>? KeyboardFocusGained;
+
+    public event EventHandler<KeyboardFocusEventArgs>? KeyboardFocusLost;
+
+    public event EventHandler<KeyEventArgs>? KeyPressed;
+
+    public event EventHandler<KeyEventArgs>? KeyReleased;
+
+    public bool HandleKeyPress(KeyEventArgs e)
+    {
+        KeyPressed?.Invoke(this, e);
+        return e.Handled;
+    }
+
+    public IReadOnlyList<KeyboardShortcut> GetKeyboardShortcuts() => Array.Empty<KeyboardShortcut>();
+
+    public new bool Focus()
+    {
+        HasKeyboardFocus = true;
+        KeyboardFocusGained?.Invoke(this, new KeyboardFocusEventArgs(true));
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
This PR delivers a deterministic architecture-conformance sweep and related documentation/testing updates.

### Architecture + Control fixes
- Auto-wire `KeyboardBehavior` in `StyledControlBase` for controls implementing `IKeyboardNavigable`
- Make theme subscription lifecycle in `StyledControlBase` safe across handler detach/reattach
- Add `OnThemeChanged` notification propagation for effective animation properties in `AnimatedControlBase`
- Align root XAML convention by adding `x:Name="thisControl"` to `Accordion` and `Wizard`
- Align control inheritance to styled base hierarchy:
  - `AccordionItem` -> `StyledControlBase`
  - `WizardStep` -> `StyledControlBase`
  - `ComboBoxPopupContent` -> `StyledControlBase`
  - `DataGridFilterPopup` -> `StyledControlBase`

### Event/Command parity
Added missing command + command parameter pairs and invocation paths:
- `Wizard`: `StepChangingCommand`, `FinishingCommand`, `CancellingCommand`
- `ComboBox`: `PopupRequestedCommand`
- `Calendar`: `DateSelectingCommand`
- `PropertyGrid`: `PropertyChangingCommand` with cancelable pre-change pipeline
- `DataGridView`: `ColumnResizingCommand`, `ExportingCommand`, `ContextMenuItemsOpeningCommand`

### Tests
- Added keyboard behavior auto-attachment tests for styled controls
- Added animated theme-change property notification tests
- Added property item pre-change/cancel tests

### Documentation + Changelog
- Reconciled architecture doc drift in `ARCHITECTURE.md`
- Updated docsify docs (`docs/architecture.md`, `docs/quickstart.md`)
- Updated `README.md`
- Updated `CHANGELOG.md` (Unreleased)
- Added `samples/DemoApp/README.md` with Android run instructions

## Validation
- `dotnet build src/MauiControlsExtras/MauiControlsExtras.csproj -f net10.0-windows10.0.19041.0`
- `dotnet test tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj`

## Closes
Closes #198
Closes #199
Closes #200
Closes #201
Closes #202
Closes #203
Closes #204
Closes #205
Closes #206