### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-02-21
 
 ### Added
 
@@ -224,7 +224,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| 1.0.0 | TBD | Initial release with 14 enterprise controls |
+| 2.0.0 | 2026-02-21 | 15 enterprise controls, keyboard/clipboard/undo-redo, dark theme, MVVM parity |
+| 1.0.0 | — | Initial release with ComboBox |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A comprehensive collection of 15 enterprise-grade UI controls for .NET MAUI appl
 [![NuGet](https://img.shields.io/nuget/v/StefK.MauiControlsExtras.svg)](https://www.nuget.org/packages/StefK.MauiControlsExtras/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **Work in Progress**: This library is under active development. APIs may change between releases. See the [Changelog](./CHANGELOG.md) for breaking changes.
-
 ## Demo Application
 
 A complete cross-platform demo app showcasing all controls is available in [`samples/DemoApp/`](./samples/DemoApp/).

--- a/src/MauiControlsExtras/MauiControlsExtras.csproj
+++ b/src/MauiControlsExtras/MauiControlsExtras.csproj
@@ -17,12 +17,12 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>StefK.MauiControlsExtras</PackageId>
-		<Version>1.0.0</Version>
+		<Version>2.0.0</Version>
 		<Authors>stef-k</Authors>
 		<Company>stef-k</Company>
 		<Product>MAUI Controls Extras</Product>
-		<Description>A collection of enhanced UI controls for .NET MAUI applications. Includes a feature-rich ComboBox control with filtering/autocomplete, custom styling, image rendering, and more.</Description>
-		<PackageTags>maui;dotnet;controls;combobox;dropdown;autocomplete;xamarin;mobile;ios;android</PackageTags>
+		<Description>A comprehensive collection of 15 enterprise-grade UI controls for .NET MAUI: Accordion, BindingNavigator, Breadcrumb, Calendar, ComboBox, DataGridView, MultiSelectComboBox, NumericUpDown, PropertyGrid, RangeSlider, Rating, RichTextEditor, TokenEntry, TreeView, and Wizard. Features keyboard navigation, clipboard support, undo/redo, dark theme, and full MVVM binding.</Description>
+		<PackageTags>maui;dotnet;controls;ui;datagrid;combobox;treeview;calendar;accordion;wizard;rating;richtext;breadcrumb;mobile;ios;android;windows;macos</PackageTags>
 		<PackageProjectUrl>https://github.com/stef-k/MauiControlsExtras</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/stef-k/MauiControlsExtras</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>


### PR DESCRIPTION
## Summary
- Bump version to 2.0.0
- Update NuGet package description and tags for the full 15-control suite
- Finalize CHANGELOG for v2.0.0 (2026-02-21)
- Remove WIP notice from README

## Notes
- Package already pushed to NuGet: https://www.nuget.org/packages/StefK.MauiControlsExtras/2.0.0
- Tag `v2.0.0` pushed
- 381 tests passing