### PR TITLE
fix(ComboBox): prevent software keyboard on iOS/Android when IsSearchVisible=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-02-23
+
+### Fixed
+
+- **ComboBox**: Software keyboard no longer appears on iOS/Android when `IsSearchVisible="False"` (#216)
+  - Hidden keyboard-capture entry focus is now restricted to desktop platforms (`WINDOWS` / `MACCATALYST`) via preprocessor guard
+  - No behavioral change on Windows or macOS — keyboard navigation continues to work when search is hidden
+
 ## [2.1.0] - 2026-02-22
 
 ### Added

--- a/docs/api/combobox.md
+++ b/docs/api/combobox.md
@@ -254,6 +254,8 @@ public bool IsSearchVisible { get; set; }
                  Placeholder="Select priority..." />
 ```
 
+> **Note:** On iOS and Android, the software keyboard does not appear when the dropdown opens with search hidden. Desktop platforms (Windows, macOS) retain hidden keyboard-capture for keyboard navigation.
+
 **Example - Dynamic toggle via binding:**
 
 ```xml

--- a/docs/controls/combobox.md
+++ b/docs/controls/combobox.md
@@ -139,6 +139,8 @@ For small item lists where search adds unnecessary complexity, hide the search i
                  Placeholder="Select status..." />
 ```
 
+> **Note:** On iOS and Android, hiding the search box also prevents the software keyboard from appearing when the dropdown opens — the dropdown is touch-only on mobile platforms.
+
 **When to hide the search box:**
 
 | Scenario | Recommendation |

--- a/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
@@ -1710,8 +1710,10 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
             }
             else
             {
+#if WINDOWS || MACCATALYST
                 // Focus the hidden keyboard capture entry for keyboard navigation when search is hidden
                 Dispatcher.Dispatch(() => keyboardCaptureEntry?.Focus());
+#endif
             }
         }
         else

--- a/src/MauiControlsExtras/Controls/ComboBox/ComboBoxPopupContent.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox/ComboBoxPopupContent.xaml.cs
@@ -139,7 +139,9 @@ public partial class ComboBoxPopupContent : StyledControlBase
         }
         else
         {
+#if WINDOWS || MACCATALYST
             Dispatcher.Dispatch(() => keyboardCaptureEntry?.Focus());
+#endif
         }
     }
 

--- a/src/MauiControlsExtras/MauiControlsExtras.csproj
+++ b/src/MauiControlsExtras/MauiControlsExtras.csproj
@@ -17,7 +17,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>StefK.MauiControlsExtras</PackageId>
-		<Version>2.1.0</Version>
+		<Version>2.1.1</Version>
 		<Authors>stef-k</Authors>
 		<Company>stef-k</Company>
 		<Product>MAUI Controls Extras</Product>


### PR DESCRIPTION
## Summary

- Guard `keyboardCaptureEntry.Focus()` with `#if WINDOWS || MACCATALYST` preprocessor directive so the hidden entry is only focused on desktop platforms
- On iOS/Android, tapping a ComboBox with `IsSearchVisible="False"` no longer triggers the software keyboard
- No behavioral change on Windows or macOS — keyboard navigation continues to work when search is hidden
- Bump version to 2.1.1

Closes #216

## Files changed

| File | Change |
|------|--------|
| `ComboBox.xaml.cs` | Preprocessor guard on `keyboardCaptureEntry?.Focus()` |
| `ComboBoxPopupContent.xaml.cs` | Same guard in `Focus()` override |
| `MauiControlsExtras.csproj` | Version 2.1.1 |
| `CHANGELOG.md` | New 2.1.1 section |
| `docs/controls/combobox.md` | Platform note in "Hiding the Search Box" |
| `docs/api/combobox.md` | Platform note under `IsSearchVisible` |

## Test plan

- [x] `dotnet build` -- all 4 targets compile with 0 errors
- [x] `dotnet test` -- 391/391 tests pass
- [ ] Manual: on iOS simulator/device, open ComboBox with `IsSearchVisible="False"` -- keyboard must NOT appear
- [ ] Manual: on Android emulator/device, same scenario -- keyboard must NOT appear
- [ ] Manual: on Windows/Mac, same setup -- keyboard navigation still works via hidden entry
