### PR TITLE
fix(DataGrid): enlarge filter icon touch target to 44x44pt minimum (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2026-02-23
+
+### Fixed
+
+- **DataGrid**: Filter icon touch target enlarged to meet 44×44pt minimum (#220)
+  - Icon wrapped in transparent `Border` with `MinimumWidthRequest = 44` / `MinimumHeightRequest = 44`
+  - `TapGestureRecognizer` attached to the wrapper for full-area tap detection
+  - Icon `FontSize` increased from 12 to 14 for improved legibility
+
 ## [2.1.2] - 2026-02-23
 
 ### Fixed
@@ -251,6 +260,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 2.1.3 | 2026-02-23 | DataGrid filter icon 44pt touch target fix |
 | 2.0.0 | 2026-02-21 | 15 enterprise controls, keyboard/clipboard/undo-redo, dark theme, MVVM parity |
 | 1.0.0 | — | Initial release with ComboBox |
 

--- a/docs/api/datagridview.md
+++ b/docs/api/datagridview.md
@@ -34,11 +34,22 @@ public class DataGridView : StyledControlBase, IUndoRedo, IClipboardSupport, IKe
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| EnableSorting | bool | false | Allow column sorting |
-| EnableFiltering | bool | false | Show filter UI |
+| CanUserSort | bool | false | Allow column sorting |
+| CanUserFilter | bool | false | Show filter UI |
 | SortColumn | string | null | Current sort column |
 | SortDirection | SortDirection | None | Current sort direction |
 | FilterExpression | string | null | Current filter |
+
+### Column Filter Properties
+
+Per-column filter state is exposed on `DataGridColumn`:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| CanUserFilter | bool | true | Whether this column shows a filter icon |
+| IsFiltered | bool | (computed) | `true` when `FilterValues` or `FilterText` is non-empty |
+| FilterValues | IEnumerable\<object\>? | null | Selected values from the filter popup checkbox list |
+| FilterText | string? | null | Text search filter applied to this column |
 
 ### Selection Properties
 

--- a/docs/controls/datagridview.md
+++ b/docs/controls/datagridview.md
@@ -53,13 +53,17 @@ A feature-rich data grid control for displaying and editing tabular data.
 ```xml
 <extras:DataGridView
     ItemsSource="{Binding Employees}"
-    EnableSorting="True"
-    EnableFiltering="True"
+    CanUserSort="True"
+    CanUserFilter="True"
     DefaultSortColumn="Name"
     DefaultSortDirection="Ascending">
     ...
 </extras:DataGridView>
 ```
+
+Per-column filtering can be controlled via `DataGridColumn.CanUserFilter`. When a column is filtered, `IsFiltered` returns `true` and the active filter state is available through `FilterValues` (checkbox-list selection) and `FilterText` (text search).
+
+> **Touch targets**: The filter icon in column headers meets the 44×44pt minimum touch target recommended by Apple HIG and Material Design guidelines.
 
 ## Column Types
 

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -3689,18 +3689,31 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
             var filterLabel = new Label
             {
                 Text = column.IsFiltered ? "⫧" : "⫶",
-                FontSize = 12,
+                FontSize = 14,
+                HorizontalOptions = LayoutOptions.Center,
                 VerticalOptions = LayoutOptions.Center,
-                TextColor = column.IsFiltered ? EffectiveAccentColor : Colors.Gray,
-                Margin = new Thickness(4, 0, 0, 0)
+                TextColor = column.IsFiltered ? EffectiveAccentColor : Colors.Gray
+            };
+
+            // Wrap in Border for 44×44pt minimum touch target (Apple HIG / Material Design)
+            var filterContainer = new Border
+            {
+                BackgroundColor = Colors.Transparent,
+                StrokeThickness = 0,
+                MinimumWidthRequest = 44,
+                MinimumHeightRequest = 44,
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.Center,
+                Margin = new Thickness(4, 0, 0, 0),
+                Content = filterLabel
             };
 
             var filterTap = new TapGestureRecognizer();
             filterTap.Tapped += (s, e) => ShowFilterPopup(column);
-            filterLabel.GestureRecognizers.Add(filterTap);
+            filterContainer.GestureRecognizers.Add(filterTap);
 
-            contentGrid.Children.Add(filterLabel);
-            Grid.SetColumn(filterLabel, 1);
+            contentGrid.Children.Add(filterContainer);
+            Grid.SetColumn(filterContainer, 1);
         }
 
         // Sort indicator (only show if sorting is enabled)

--- a/src/MauiControlsExtras/MauiControlsExtras.csproj
+++ b/src/MauiControlsExtras/MauiControlsExtras.csproj
@@ -17,7 +17,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>StefK.MauiControlsExtras</PackageId>
-		<Version>2.1.2</Version>
+		<Version>2.1.3</Version>
 		<Authors>stef-k</Authors>
 		<Company>stef-k</Company>
 		<Product>MAUI Controls Extras</Product>

--- a/tests/MauiControlsExtras.Tests/Controls/DataGridColumnTests.cs
+++ b/tests/MauiControlsExtras.Tests/Controls/DataGridColumnTests.cs
@@ -167,4 +167,147 @@ public class DataGridColumnTests
         Assert.False(failResult.IsValid);
         Assert.Equal("Required", failResult.FirstError);
     }
+
+    // --- FilterValues tests ---
+
+    [Fact]
+    public void FilterValues_DefaultsToNull()
+    {
+        var col = new DataGridTextColumn();
+        Assert.Null(col.FilterValues);
+    }
+
+    [Fact]
+    public void FilterValues_Set_RaisesPropertyChanged()
+    {
+        var col = new DataGridTextColumn();
+        var raised = new List<string>();
+        col.PropertyChanged += (_, e) => raised.Add(e.PropertyName!);
+
+        col.FilterValues = new object[] { "A", "B" };
+
+        Assert.Contains(nameof(DataGridColumn.FilterValues), raised);
+        Assert.Contains(nameof(DataGridColumn.IsFiltered), raised);
+    }
+
+    [Fact]
+    public void FilterValues_NonEmpty_SetsIsFilteredTrue()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterValues = new object[] { "A" };
+        Assert.True(col.IsFiltered);
+    }
+
+    [Fact]
+    public void FilterValues_EmptyCollection_SetsIsFilteredFalse()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterValues = Enumerable.Empty<object>();
+        Assert.False(col.IsFiltered);
+    }
+
+    [Fact]
+    public void FilterValues_ResetToNull_SetsIsFilteredFalse()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterValues = new object[] { "A" };
+        Assert.True(col.IsFiltered);
+
+        col.FilterValues = null;
+        Assert.False(col.IsFiltered);
+    }
+
+    // --- FilterText tests ---
+
+    [Fact]
+    public void FilterText_DefaultsToNull()
+    {
+        var col = new DataGridTextColumn();
+        Assert.Null(col.FilterText);
+    }
+
+    [Fact]
+    public void FilterText_Set_RaisesPropertyChanged()
+    {
+        var col = new DataGridTextColumn();
+        var raised = new List<string>();
+        col.PropertyChanged += (_, e) => raised.Add(e.PropertyName!);
+
+        col.FilterText = "search";
+
+        Assert.Contains(nameof(DataGridColumn.FilterText), raised);
+        Assert.Contains(nameof(DataGridColumn.IsFiltered), raised);
+    }
+
+    [Fact]
+    public void FilterText_NonEmpty_SetsIsFilteredTrue()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterText = "search";
+        Assert.True(col.IsFiltered);
+    }
+
+    [Fact]
+    public void FilterText_EmptyString_SetsIsFilteredFalse()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterText = "";
+        Assert.False(col.IsFiltered);
+    }
+
+    [Fact]
+    public void FilterText_ResetToNull_SetsIsFilteredFalse()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterText = "search";
+        Assert.True(col.IsFiltered);
+
+        col.FilterText = null;
+        Assert.False(col.IsFiltered);
+    }
+
+    // --- IsFiltered combined tests ---
+
+    [Fact]
+    public void IsFiltered_FalseByDefault()
+    {
+        var col = new DataGridTextColumn();
+        Assert.False(col.IsFiltered);
+    }
+
+    [Fact]
+    public void IsFiltered_TrueWithOnlyFilterValues()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterValues = new object[] { 1, 2 };
+        Assert.True(col.IsFiltered);
+        Assert.Null(col.FilterText);
+    }
+
+    [Fact]
+    public void IsFiltered_TrueWithOnlyFilterText()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterText = "abc";
+        Assert.True(col.IsFiltered);
+        Assert.Null(col.FilterValues);
+    }
+
+    [Fact]
+    public void IsFiltered_TrueWithBoth()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterValues = new object[] { "X" };
+        col.FilterText = "Y";
+        Assert.True(col.IsFiltered);
+    }
+
+    [Fact]
+    public void IsFiltered_FalseWhenBothEmptyOrNull()
+    {
+        var col = new DataGridTextColumn();
+        col.FilterValues = Enumerable.Empty<object>();
+        col.FilterText = "";
+        Assert.False(col.IsFiltered);
+    }
 }


### PR DESCRIPTION
## Summary

- Wrap filter icon label in transparent `Border` with `MinimumWidthRequest=44` / `MinimumHeightRequest=44` to meet Apple HIG and Material Design 44pt minimum touch target
- Move `TapGestureRecognizer` from label to Border wrapper for full-area tap detection
- Bump icon `FontSize` from 12 to 14 for improved legibility
- Add 14 unit tests covering `FilterValues`, `FilterText`, and `IsFiltered` properties
- Fix outdated property names in docs (`EnableSorting`/`EnableFiltering` -> `CanUserSort`/`CanUserFilter`)
- Version bump 2.1.2 -> 2.1.3

## Test plan

- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (406/406, including 14 new filter property tests)
- [x] Visual verification on Windows DemoApp: filter icon tappable, popup opens, header alignment preserved
- [ ] Mobile verification deferred (pattern matches proven TokenEntry/TreeView/Calendar implementation from #172)