### PR TITLE
feat(ComboBox): add SelectedIndex property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ComboBox**: `SelectedIndex` bindable property for position-based selection (#243)
+
 ### Fixed
 
 - **DataGrid**: Page size picker text is now horizontally centered (#239)

--- a/docs/controls/combobox.md
+++ b/docs/controls/combobox.md
@@ -90,6 +90,33 @@ public class IconOption
 
 > **Note:** Icon images should be placed in the `Resources/Raw` folder of your MAUI project.
 
+## Selection Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SelectedItem` | `object?` | `null` | The currently selected item object |
+| `SelectedValue` | `object?` | `null` | The value of the selected item (via `ValueMemberPath`/`ValueMemberFunc`) |
+| `SelectedIndex` | `int` | `-1` | Zero-based index of the selected item in `ItemsSource` |
+
+All three properties stay in sync automatically. Setting any one updates the others.
+
+## Selecting by Index
+
+Use `SelectedIndex` for position-based selection. The index refers to the position in `ItemsSource` (the original collection), not the filtered list.
+
+```xml
+<extras:ComboBox ItemsSource="{Binding Departments}"
+                 SelectedIndex="{Binding SelectedDepartmentIndex}"
+                 Placeholder="Select a department..." />
+```
+
+**Notes:**
+- `-1` means no selection (default)
+- Setting an out-of-range index is a silent no-op — no crash, no selection change
+- If `SelectedIndex` is set before `ItemsSource`, the selection resolves once items arrive
+- When `SelectedItem` changes (e.g., from dropdown pick), `SelectedIndex` updates automatically
+- The index always refers to `ItemsSource`, not `FilteredItems` (the search-filtered subset)
+
 ## Default Values
 
 Set a default selection when the control loads:

--- a/samples/DemoApp/ViewModels/ComboBoxDemoViewModel.cs
+++ b/samples/DemoApp/ViewModels/ComboBoxDemoViewModel.cs
@@ -19,6 +19,9 @@ public partial class ComboBoxDemoViewModel : BaseViewModel
     private string? _selectedDepartment;
 
     [ObservableProperty]
+    private int _selectedDepartmentIndex = -1;
+
+    [ObservableProperty]
     private ObservableCollection<string> _departments = [];
 
     [ObservableProperty]
@@ -64,6 +67,11 @@ public partial class ComboBoxDemoViewModel : BaseViewModel
     {
         if (value is not null)
             UpdateStatus($"Selected department: {value}");
+    }
+
+    partial void OnSelectedDepartmentIndexChanged(int value)
+    {
+        UpdateStatus($"Selected department index: {value}");
     }
 
     partial void OnSelectedEmployeeChanged(Employee? value)

--- a/samples/DemoApp/Views/ComboBoxDemoPage.xaml
+++ b/samples/DemoApp/Views/ComboBoxDemoPage.xaml
@@ -31,6 +31,23 @@
                 </VerticalStackLayout>
             </Frame>
 
+            <!-- SelectedIndex Binding -->
+            <Frame Style="{StaticResource DemoCardStyle}">
+                <VerticalStackLayout Spacing="15">
+                    <Label Text="SelectedIndex Binding" Style="{StaticResource SectionTitleStyle}" />
+                    <Label Text="Select by position in ItemsSource. Index syncs with SelectedItem."
+                           Style="{StaticResource SectionDescriptionStyle}" />
+
+                    <extras:ComboBox ItemsSource="{Binding Departments}"
+                                     SelectedIndex="{Binding SelectedDepartmentIndex}"
+                                     Placeholder="Select by index..."
+                                     WidthRequest="300"
+                                     HorizontalOptions="Start" />
+
+                    <Label Text="{Binding SelectedDepartmentIndex, StringFormat='SelectedIndex: {0}'}" />
+                </VerticalStackLayout>
+            </Frame>
+
             <!-- Country Selector with Icons -->
             <Frame Style="{StaticResource DemoCardStyle}">
                 <VerticalStackLayout Spacing="15">


### PR DESCRIPTION
## Summary

- Adds `SelectedIndex` bindable property (`int`, default `-1`, two-way) to ComboBox for position-based selection (#243)
- Index refers to `ItemsSource` position (not filtered items), matching WPF/WinForms semantics
- Stays in sync with `SelectedItem` and `SelectedValue` via the existing `_isUpdatingFromSelection` guard
- Out-of-range index is a silent no-op; setting index before `ItemsSource` defers resolution until items arrive

## Changes

- **ComboBox.xaml.cs**: `SelectedIndexProperty`, `SelectItemByIndex()`, `FindIndexInItemsSource()`, `FindItemAtIndex()`, `SyncSelectionAfterItemsSourceChanged()`, plus sync in 5 existing methods
- **CHANGELOG.md**: Added entry under `[Unreleased]`
- **combobox.md**: Selection Properties table + "Selecting by Index" section
- **Demo app**: New SelectedIndex demo card with VM binding

## Test plan

- [ ] Set `SelectedIndex` in XAML → correct item selected on load
- [ ] Change `SelectedIndex` from VM → `SelectedItem` and `SelectedValue` update
- [ ] Pick item from dropdown → `SelectedIndex` updates in VM
- [ ] Set `SelectedItem` from VM → `SelectedIndex` updates
- [ ] Set `SelectedValue` from VM → `SelectedIndex` updates
- [ ] `ClearSelection()` → `SelectedIndex` becomes -1
- [ ] Set `SelectedIndex` to -1 → selection cleared
- [ ] Set `SelectedIndex` out of range → no crash, no change
- [ ] Replace `ItemsSource` → `SelectedIndex` recalculates
- [ ] Set `SelectedIndex` before `ItemsSource` → resolves once ItemsSource arrives
- [ ] Use with search/filter → index still refers to `ItemsSource` position