### PR TITLE
fix(ComboBox): avoid ClearSelection side effects in SelectItemByIndex

### DIFF
--- a/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
@@ -1334,7 +1334,20 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
     {
         if (index < 0)
         {
-            ClearSelection();
+            var wasGuarded = _isUpdatingFromSelection;
+            _isUpdatingFromSelection = true;
+            try
+            {
+                SelectedItem = null;
+                SelectedValue = null;
+                UpdateDisplayState();
+            }
+            finally
+            {
+                _isUpdatingFromSelection = wasGuarded;
+            }
+
+            RaiseSelectionChanged(null);
             return;
         }
 
@@ -1345,6 +1358,7 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
         if (item == null)
             return;
 
+        var alreadyGuarded = _isUpdatingFromSelection;
         _isUpdatingFromSelection = true;
         try
         {
@@ -1359,7 +1373,7 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
         }
         finally
         {
-            _isUpdatingFromSelection = false;
+            _isUpdatingFromSelection = alreadyGuarded;
         }
 
         RaiseSelectionChanged(item);


### PR DESCRIPTION
## Summary

- `SelectItemByIndex(-1)` no longer delegates to `ClearSelection()`, avoiding unexpected `ClearCommand`/`Close()` side effects
- Guard state (`_isUpdatingFromSelection`) is now preserved across nested calls, preventing premature reset when called from `SyncSelectionAfterItemsSourceChanged`

Follow-up fix from code review of #245.

## Test plan

- [ ] Set `SelectedIndex = -1` programmatically → selection clears without firing `ClearCommand` or closing the dropdown
- [ ] Replace `ItemsSource` while `SelectedIndex >= 0` and `SelectedItem == null` → deferred index resolution works without guard issues