### PR TITLE
fix(AOT): add missing [DynamicDependency] annotations and fix dead binding (#251, #252, #253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ComboBox**: `SelectedIndex` bindable property for position-based selection (#243)
 - **MultiSelectComboBox**: `SelectedIndices` bindable property for position-based multi-selection (#244)
 
+### Removed
+
+- **DataGrid**: Removed `DataGridColumn.SortIndicator` public property — sort indicator is now managed internally (#252)
+
 ### Fixed
 
 - **AOT/Trimming**: Replaced DataGrid sort indicator `SetBinding` + `SortIndicatorConverter` with direct `PropertyChanged` subscription to eliminate CLR-property binding hazard (#240)
@@ -21,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AOT/Trimming**: Added `[Preserve(AllMembers = true)]` on `InvertedBoolConverter`, `MauiAssetImageConverter`, and `FuncDisplayConverter` to protect against trimming (#240)
 - **AOT/Trimming**: Added `x:DataType="x:String"` to TokenEntry suggestion `DataTemplate` for compiled bindings (#240)
 - **AOT/Trimming**: Added XML doc `<remarks>` warnings on `DisplayMemberPath` and `IconMemberPath` (ComboBox, MultiSelectComboBox) advising AOT-safe alternatives (#240)
+- **AOT/Trimming**: Added `[DynamicDependency]` annotations for CLR properties on RangeSlider, DataGridView, BindingNavigator, RichTextEditor, and PropertyGrid (#251)
+- **Breadcrumb**: Removed dead `EffectiveBackgroundColor` binding targeting a non-existent property (#253)
 - **DataGrid**: Fixed virtualization crash on Windows debug builds caused by async handler re-attachment race during row recycling (#237)
 - **DataGrid**: Page size picker text is now horizontally centered (#239)
 - **DataGrid**: Header text color now reacts to `ForegroundColor` property changes without requiring a full refresh (#238)

--- a/src/MauiControlsExtras/Controls/BindingNavigator/BindingNavigator.xaml.cs
+++ b/src/MauiControlsExtras/Controls/BindingNavigator/BindingNavigator.xaml.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using MauiControlsExtras.Base;
 
@@ -844,6 +845,8 @@ public partial class BindingNavigator : StyledControlBase, IKeyboardNavigable
     /// <summary>
     /// Initializes a new instance of the <see cref="BindingNavigator"/> class.
     /// </summary>
+    [DynamicDependency(nameof(DisplayPosition), typeof(BindingNavigator))]
+    [DynamicDependency(nameof(Count), typeof(BindingNavigator))]
     public BindingNavigator()
     {
         InitializeComponent();

--- a/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml
+++ b/src/MauiControlsExtras/Controls/Breadcrumb/Breadcrumb.xaml
@@ -8,7 +8,6 @@
 
     <Border StrokeThickness="{Binding EffectiveBorderThickness, Source={x:Reference thisControl}}"
             Stroke="{Binding CurrentBorderColor, Source={x:Reference thisControl}}"
-            BackgroundColor="{Binding EffectiveBackgroundColor, Source={x:Reference thisControl}}"
             Padding="{Binding Padding, Source={x:Reference thisControl}}">
         <Border.StrokeShape>
             <RoundRectangle CornerRadius="{Binding EffectiveCornerRadius, Source={x:Reference thisControl}}" />

--- a/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
+++ b/src/MauiControlsExtras/Controls/DataGrid/DataGridView.xaml.cs
@@ -2328,6 +2328,9 @@ public partial class DataGridView : Base.ListStyledControlBase, Base.IUndoRedo, 
     /// <summary>
     /// Initializes a new instance of the DataGridView control.
     /// </summary>
+    [DynamicDependency(nameof(HasFrozenColumns), typeof(DataGridView))]
+    [DynamicDependency(nameof(PageInfoText), typeof(DataGridView))]
+    [DynamicDependency(nameof(CurrentPageText), typeof(DataGridView))]
     public DataGridView()
     {
         InitializeComponent();

--- a/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/PropertyGrid.xaml.cs
@@ -625,6 +625,7 @@ public partial class PropertyGrid : HeaderedControlBase, IKeyboardNavigable
     /// <summary>
     /// Initializes a new instance of the <see cref="PropertyGrid"/> class.
     /// </summary>
+    [DynamicDependency(nameof(HasSearchText), typeof(PropertyGrid))]
     public PropertyGrid()
     {
         InitializeComponent();

--- a/src/MauiControlsExtras/Controls/RangeSlider.xaml.cs
+++ b/src/MauiControlsExtras/Controls/RangeSlider.xaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using MauiControlsExtras.Base;
 using MauiControlsExtras.Base.Validation;
@@ -754,6 +755,25 @@ public partial class RangeSlider : StyledControlBase, IValidatable, Base.IKeyboa
     /// <summary>
     /// Initializes a new instance of the RangeSlider control.
     /// </summary>
+    [DynamicDependency(nameof(EffectiveTrackColor), typeof(RangeSlider))]
+    [DynamicDependency(nameof(EffectiveRangeColor), typeof(RangeSlider))]
+    [DynamicDependency(nameof(EffectiveThumbColor), typeof(RangeSlider))]
+    [DynamicDependency(nameof(TrackCornerRadius), typeof(RangeSlider))]
+    [DynamicDependency(nameof(TrackAreaHeight), typeof(RangeSlider))]
+    [DynamicDependency(nameof(IsHorizontal), typeof(RangeSlider))]
+    [DynamicDependency(nameof(IsVertical), typeof(RangeSlider))]
+    [DynamicDependency(nameof(LowerLabelText), typeof(RangeSlider))]
+    [DynamicDependency(nameof(UpperLabelText), typeof(RangeSlider))]
+    [DynamicDependency(nameof(MinLabelText), typeof(RangeSlider))]
+    [DynamicDependency(nameof(MaxLabelText), typeof(RangeSlider))]
+    [DynamicDependency(nameof(LowerThumbPosition), typeof(RangeSlider))]
+    [DynamicDependency(nameof(UpperThumbPosition), typeof(RangeSlider))]
+    [DynamicDependency(nameof(LowerThumbPositionVertical), typeof(RangeSlider))]
+    [DynamicDependency(nameof(UpperThumbPositionVertical), typeof(RangeSlider))]
+    [DynamicDependency(nameof(RangeTrackMargin), typeof(RangeSlider))]
+    [DynamicDependency(nameof(RangeTrackWidth), typeof(RangeSlider))]
+    [DynamicDependency(nameof(RangeTrackMarginVertical), typeof(RangeSlider))]
+    [DynamicDependency(nameof(RangeTrackHeightVertical), typeof(RangeSlider))]
     public RangeSlider()
     {
         InitializeComponent();

--- a/src/MauiControlsExtras/Controls/RichTextEditor/RichTextEditor.xaml.cs
+++ b/src/MauiControlsExtras/Controls/RichTextEditor/RichTextEditor.xaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Windows.Input;
 using MauiControlsExtras.Base;
@@ -1220,6 +1221,9 @@ public partial class RichTextEditor : TextStyledControlBase, IKeyboardNavigable,
     /// <summary>
     /// Initializes a new instance of the <see cref="RichTextEditor"/> class.
     /// </summary>
+    [DynamicDependency(nameof(EffectiveEditorBackground), typeof(RichTextEditor))]
+    [DynamicDependency(nameof(ShowTopToolbar), typeof(RichTextEditor))]
+    [DynamicDependency(nameof(ShowBottomToolbar), typeof(RichTextEditor))]
     public RichTextEditor()
     {
         InitializeComponent();


### PR DESCRIPTION
## Summary

Follow-up to PR #250 addressing remaining AOT/trimming hazards found during final review.

- **RangeSlider**: Added `[DynamicDependency]` for 19 CLR-only properties bound in XAML (track colors, thumb positions, label texts, orientation flags, track dimensions)
- **DataGridView**: Added `[DynamicDependency]` for `HasFrozenColumns`, `PageInfoText`, `CurrentPageText`
- **BindingNavigator**: Added `[DynamicDependency]` for `DisplayPosition`, `Count`
- **RichTextEditor**: Added `[DynamicDependency]` for `EffectiveEditorBackground`, `ShowTopToolbar`, `ShowBottomToolbar`
- **PropertyGrid**: Added `[DynamicDependency]` for `HasSearchText`
- **Breadcrumb**: Removed dead `EffectiveBackgroundColor` binding (property does not exist in the type hierarchy)
- **CHANGELOG**: Documented `DataGridColumn.SortIndicator` removal under `### Removed`

Closes #251, closes #252, closes #253

## Test plan

- [x] Library builds with 0 errors (Release)
- [x] All 510 tests pass
- [x] Demo app builds with 0 errors
- [ ] Verify RangeSlider renders correctly (track, thumbs, labels)
- [ ] Verify DataGrid pagination info displays correctly
- [ ] Verify Breadcrumb renders without visual regression after removing dead binding