### PR TITLE
chore: release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-02-26
+
 ### Added
 
 - **ComboBox**: `SelectedIndex` bindable property for position-based selection (#243)
@@ -32,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DataGrid**: Header text color now reacts to `ForegroundColor` property changes without requiring a full refresh (#238)
 - **ComboBox**: Selected item now displays correctly when `DisplayMemberPath`/`DisplayMemberFunc` is set after `SelectedItem` (#235)
 - **ComboBox**: Dropdown now highlights the currently selected item when opened instead of always highlighting the first item (#236)
+- **ComboBox**: `SelectItemByIndex(-1)` no longer triggers `ClearCommand` and popup close as side effects (#246)
 
 ## [3.0.0] - 2026-02-25
 
@@ -350,6 +353,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 3.1.0 | 2026-02-26 | SelectedIndex/SelectedIndices features, AOT/trimming fixes, DataGrid virtualization crash fix, ComboBox selection fixes |
 | 3.0.0 | 2026-02-25 | AOT/trimming safety for all controls, Func-based property accessors, PropertyMetadataRegistry (#232, #233) |
 | 2.1.8 | 2026-02-24 | DataGrid theme-reactive headers, pagination layout, picker centering, cell text colors (#231) |
 | 2.1.7 | 2026-02-23 | DataGrid filter popup null-value checkbox preservation (#217) |

--- a/src/MauiControlsExtras/MauiControlsExtras.csproj
+++ b/src/MauiControlsExtras/MauiControlsExtras.csproj
@@ -22,7 +22,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>StefK.MauiControlsExtras</PackageId>
-		<Version>3.0.0</Version>
+		<Version>3.1.0</Version>
 		<Authors>stef-k</Authors>
 		<Company>stef-k</Company>
 		<Product>MAUI Controls Extras</Product>


### PR DESCRIPTION
## Summary

- Bump version from 3.0.0 → 3.1.0
- Finalize changelog: move `[Unreleased]` entries to `[3.1.0] - 2026-02-26`
- Add missing ComboBox `ClearSelection` side-effect fix entry (#246)
- Update version history table

## Changes since 3.0.0

### Features
- **ComboBox**: `SelectedIndex` bindable property (#243)
- **MultiSelectComboBox**: `SelectedIndices` bindable property (#244)

### Fixes
- 8 AOT/trimming hazard fixes (#240, #251)
- DataGrid virtualization crash on Windows debug builds (#237)
- DataGrid header text color reactivity (#238), page-size picker centering (#239)
- ComboBox display text with late DisplayMemberPath (#235), dropdown highlight (#236), ClearSelection side effects (#246)
- Breadcrumb dead binding removal (#253)

### Removed
- `DataGridColumn.SortIndicator` public property (internal implementation detail, #252)

## Test plan
- [ ] Verify CHANGELOG.md formatting and completeness
- [ ] Verify csproj version is 3.1.0
- [ ] Build succeeds for all target frameworks
- [ ] NuGet pack produces correct version