### PR TITLE
chore: release v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-02-26
+
 ### Added
 
 - **Docs**: Centralized AOT & Trimming guide (`docs/aot.md`) with Func-based property reference table, code examples, and links to per-control sections

--- a/src/MauiControlsExtras/MauiControlsExtras.csproj
+++ b/src/MauiControlsExtras/MauiControlsExtras.csproj
@@ -22,7 +22,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>StefK.MauiControlsExtras</PackageId>
-		<Version>3.1.0</Version>
+		<Version>3.1.1</Version>
 		<Authors>stef-k</Authors>
 		<Company>stef-k</Company>
 		<Product>MAUI Controls Extras</Product>


### PR DESCRIPTION
## Summary
- Bump version to 3.1.1
- Move CHANGELOG `[Unreleased]` entries to `[3.1.1]`

## Changes since v3.1.0
- **Docs**: Centralized AOT & Trimming guide (`docs/aot.md`)