### PR TITLE
fix(AOT): eliminate IL2026 trim warnings from Binding constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AOT/Trimming**: Eliminate IL2026 trim warnings from `Binding` constructor — migrate internal self-bindings to expression-based `SetBinding` and suppress intentional reflection fallbacks (#259)
 - **DataGrid**: Fix `StackOverflowException` crash when using `Fill` column sizing mode — re-entrant `SizeChanged` on WinUI caused infinite recursion during column width distribution
 - **Theming**: Controls now respond to MAUI `RequestedThemeChanged`, fixing theme-dependent properties not updating when toggling `UserAppTheme` at runtime (#258)
 

--- a/src/MauiControlsExtras/Controls/Accordion/Accordion.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Accordion/Accordion.xaml.cs
@@ -786,7 +786,7 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         var cornerRadiusShape = new RoundRectangle();
         cornerRadiusShape.SetBinding(
             RoundRectangle.CornerRadiusProperty,
-            new Binding(nameof(EffectiveCornerRadius), source: this));
+            static (Accordion a) => a.EffectiveCornerRadius, source: this);
 
         // Create the border
         var border = new Border
@@ -798,10 +798,10 @@ public partial class Accordion : HeaderedControlBase, IKeyboardNavigable, ISelec
         // Set up bindings for border
         border.SetBinding(
             Border.StrokeThicknessProperty,
-            new Binding(nameof(EffectiveBorderThickness), source: this));
+            static (Accordion a) => a.EffectiveBorderThickness, source: this);
         border.SetBinding(
             Border.StrokeProperty,
-            new Binding(nameof(CurrentBorderColor), source: this));
+            static (Accordion a) => a.CurrentBorderColor, source: this);
 
         // Set background color with theme support
         border.SetAppThemeColor(Border.BackgroundColorProperty,

--- a/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox.xaml.cs
@@ -1697,6 +1697,8 @@ public partial class ComboBox : TextStyledControlBase, IValidatable, Base.IKeybo
         }
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode",
+        Justification = "Reflection fallback for non-AOT scenarios. Use DisplayMemberFunc/IconMemberFunc for AOT compatibility.")]
     private void SetupItemTemplate()
     {
         // If a custom ItemTemplate is provided, use it directly

--- a/src/MauiControlsExtras/Controls/ComboBox/ComboBoxPopupContent.xaml.cs
+++ b/src/MauiControlsExtras/Controls/ComboBox/ComboBoxPopupContent.xaml.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using MauiControlsExtras.Base;
 using MauiControlsExtras.Helpers;
 
@@ -223,6 +224,8 @@ public partial class ComboBoxPopupContent : StyledControlBase
         UpdateFilteredItems(searchText);
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode",
+        Justification = "Reflection fallback for non-AOT scenarios. Use DisplayMemberFunc for AOT compatibility.")]
     private void SetupItemTemplate()
     {
         var displayMemberPath = _displayMemberPath;

--- a/src/MauiControlsExtras/Controls/MultiSelectComboBox.xaml.cs
+++ b/src/MauiControlsExtras/Controls/MultiSelectComboBox.xaml.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using MauiControlsExtras.Base;
 using MauiControlsExtras.Base.Validation;
@@ -1324,6 +1325,8 @@ public partial class MultiSelectComboBox : TextStyledControlBase, IValidatable, 
         }
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode",
+        Justification = "Reflection fallback for non-AOT scenarios. Use DisplayMemberFunc for AOT compatibility.")]
     private void SetupItemTemplate()
     {
         // If a custom ItemTemplate is provided, wrap it with checkbox support
@@ -1347,7 +1350,7 @@ public partial class MultiSelectComboBox : TextStyledControlBase, IValidatable, 
                 {
                     VerticalOptions = LayoutOptions.Center
                 };
-                checkBox.SetBinding(CheckBox.ColorProperty, new Binding(nameof(EffectiveAccentColor), source: this));
+                checkBox.SetBinding(CheckBox.ColorProperty, static (MultiSelectComboBox c) => c.EffectiveAccentColor, source: this);
                 checkBox.CheckedChanged += OnItemCheckChanged;
                 Grid.SetColumn(checkBox, 0);
                 grid.Add(checkBox);
@@ -1412,7 +1415,7 @@ public partial class MultiSelectComboBox : TextStyledControlBase, IValidatable, 
             {
                 VerticalOptions = LayoutOptions.Center
             };
-            checkBox.SetBinding(CheckBox.ColorProperty, new Binding(nameof(EffectiveAccentColor), source: this));
+            checkBox.SetBinding(CheckBox.ColorProperty, static (MultiSelectComboBox c) => c.EffectiveAccentColor, source: this);
             checkBox.CheckedChanged += OnItemCheckChanged;
             Grid.SetColumn(checkBox, 0);
             grid.Add(checkBox);

--- a/src/MauiControlsExtras/Controls/PropertyGrid/IPropertyEditor.cs
+++ b/src/MauiControlsExtras/Controls/PropertyGrid/IPropertyEditor.cs
@@ -37,6 +37,8 @@ public abstract class PropertyEditorBase : IPropertyEditor
     /// Creates a binding to the property value.
     /// </summary>
     [DynamicDependency(nameof(PropertyItem.Value), typeof(PropertyItem))]
+    [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode",
+        Justification = "Binds to PropertyItem.Value which is preserved via DynamicDependency.")]
     protected Binding CreateValueBinding(PropertyItem property, BindingMode mode = BindingMode.TwoWay)
     {
         return new Binding(nameof(PropertyItem.Value), mode, source: property);

--- a/src/MauiControlsExtras/Controls/Wizard/Wizard.xaml.cs
+++ b/src/MauiControlsExtras/Controls/Wizard/Wizard.xaml.cs
@@ -1021,9 +1021,9 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
             Content = indicatorScrollView
         };
         stepIndicatorTop.SetBinding(Border.BackgroundColorProperty,
-            new Binding(nameof(EffectiveStepIndicatorBackgroundColor), source: this));
+            static (Wizard w) => w.EffectiveStepIndicatorBackgroundColor, source: this);
         stepIndicatorTop.SetBinding(Border.PaddingProperty,
-            new Binding(nameof(StepIndicatorPadding), source: this));
+            static (Wizard w) => w.StepIndicatorPadding, source: this);
 
         // Step title label
         stepTitleLabel = new Label
@@ -1031,11 +1031,11 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
             Margin = new Thickness(0, 0, 0, 4)
         };
         stepTitleLabel.SetBinding(Label.FontSizeProperty,
-            new Binding(nameof(StepTitleFontSize), source: this));
+            static (Wizard w) => w.StepTitleFontSize, source: this);
         stepTitleLabel.SetBinding(Label.FontAttributesProperty,
-            new Binding(nameof(StepTitleFontAttributes), source: this));
+            static (Wizard w) => w.StepTitleFontAttributes, source: this);
         stepTitleLabel.SetBinding(Label.TextColorProperty,
-            new Binding(nameof(EffectiveForegroundColor), source: this));
+            static (Wizard w) => w.EffectiveForegroundColor, source: this);
 
         // Step description label
         stepDescriptionLabel = new Label
@@ -1092,9 +1092,9 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
             BackgroundColor = Colors.Transparent
         };
         cancelButton.SetBinding(Button.TextProperty,
-            new Binding(nameof(CancelButtonText), source: this));
+            static (Wizard w) => w.CancelButtonText, source: this);
         cancelButton.SetBinding(Button.IsVisibleProperty,
-            new Binding(nameof(ShowCancelButton), source: this));
+            static (Wizard w) => w.ShowCancelButton, source: this);
         cancelButton.SetAppThemeColor(Button.TextColorProperty,
             Color.FromArgb("#666666"),
             Color.FromArgb("#AAAAAA"));
@@ -1107,7 +1107,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
             Margin = new Thickness(0, 0, 8, 0)
         };
         skipButton.SetBinding(Button.TextProperty,
-            new Binding(nameof(SkipButtonText), source: this));
+            static (Wizard w) => w.SkipButtonText, source: this);
         skipButton.SetAppThemeColor(Button.TextColorProperty,
             Color.FromArgb("#666666"),
             Color.FromArgb("#AAAAAA"));
@@ -1118,14 +1118,14 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
             Margin = new Thickness(0, 0, 8, 0)
         };
         backButton.SetBinding(Button.TextProperty,
-            new Binding(nameof(BackButtonText), source: this));
+            static (Wizard w) => w.BackButtonText, source: this);
         backButton.SetBinding(Button.IsVisibleProperty,
-            new Binding(nameof(ShowBackButton), source: this));
+            static (Wizard w) => w.ShowBackButton, source: this);
         backButton.SetAppThemeColor(Button.BackgroundColorProperty,
             Color.FromArgb("#E0E0E0"),
             Color.FromArgb("#404040"));
         backButton.SetBinding(Button.TextColorProperty,
-            new Binding(nameof(EffectiveForegroundColor), source: this));
+            static (Wizard w) => w.EffectiveForegroundColor, source: this);
         backButton.Clicked += OnBackClicked;
 
         nextButton = new Button
@@ -1133,9 +1133,9 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
             TextColor = Colors.White
         };
         nextButton.SetBinding(Button.TextProperty,
-            new Binding(nameof(NextButtonText), source: this));
+            static (Wizard w) => w.NextButtonText, source: this);
         nextButton.SetBinding(Button.BackgroundColorProperty,
-            new Binding(nameof(EffectiveAccentColor), source: this));
+            static (Wizard w) => w.EffectiveAccentColor, source: this);
         nextButton.Clicked += OnNextClicked;
 
         // Navigation grid
@@ -1183,7 +1183,7 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
         // Corner radius shape
         var cornerRadiusShape = new RoundRectangle();
         cornerRadiusShape.SetBinding(RoundRectangle.CornerRadiusProperty,
-            new Binding(nameof(EffectiveCornerRadius), source: this));
+            static (Wizard w) => w.EffectiveCornerRadius, source: this);
 
         // Outer border
         var outerBorder = new Border
@@ -1192,9 +1192,9 @@ public partial class Wizard : NavigationControlBase, IKeyboardNavigable
             Content = mainGrid
         };
         outerBorder.SetBinding(Border.StrokeThicknessProperty,
-            new Binding(nameof(EffectiveBorderThickness), source: this));
+            static (Wizard w) => w.EffectiveBorderThickness, source: this);
         outerBorder.SetBinding(Border.StrokeProperty,
-            new Binding(nameof(CurrentBorderColor), source: this));
+            static (Wizard w) => w.CurrentBorderColor, source: this);
         outerBorder.SetAppThemeColor(Border.BackgroundColorProperty,
             Color.FromArgb("#FFFFFF"),
             Color.FromArgb("#1E1E1E"));


### PR DESCRIPTION
## Summary

- Migrate 21 internal self-bindings to expression-based `SetBinding<TSource, TProperty>()` — eliminates IL2026 warnings at the source
- Suppress 4 intentional reflection-fallback methods with `[UnconditionalSuppressMessage]` — these have documented `Func`-based AOT alternatives

## Changes

| File | Self-bindings converted | Suppressions added | Import added |
|------|------------------------|--------------------|--------------|
| Wizard.xaml.cs | 16 | 0 | No |
| Accordion.xaml.cs | 3 | 0 | No |
| MultiSelectComboBox.xaml.cs | 2 | 1 (method) | Yes |
| ComboBox.xaml.cs | 0 | 1 (method) | No |
| ComboBoxPopupContent.xaml.cs | 0 | 1 (method) | Yes |
| IPropertyEditor.cs | 0 | 1 (method) | No |
| **Total** | **21** | **4** | **2** |

## Test plan

- [x] `dotnet build` Release — zero IL2026 warnings
- [x] `dotnet test` — 521/521 pass
- [x] DemoApp builds cleanly

Closes #259