### PR TITLE
fix(Build): re-enable test project build in Debug solution config

### DIFF
--- a/MauiControlsExtras.slnx
+++ b/MauiControlsExtras.slnx
@@ -3,9 +3,7 @@
     <Project Path="src/MauiControlsExtras/MauiControlsExtras.csproj" />
   </Folder>
   <Folder Name="/tests/">
-    <Project Path="tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj">
-      <Build Solution="Debug|*" Project="false" />
-    </Project>
+    <Project Path="tests/MauiControlsExtras.Tests/MauiControlsExtras.Tests.csproj" />
   </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/DemoApp/DemoApp.csproj">


### PR DESCRIPTION
## Summary

- Reverts `Project="false"` on the test project in `.slnx` that was accidentally introduced in #264
- Test project now compiles again during normal Debug solution builds, catching breakages early

## Test plan

- [x] Verify `MauiControlsExtras.slnx` no longer excludes test project from Debug builds
- [x] `dotnet test` — all 521 tests pass