### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-02-26
+
 ### Added
 
 - **DataGrid**: `DataGridColumnSizeMode` enum (`Auto`, `Fixed`, `FitHeader`, `Fill`) for per-column width behavior
@@ -371,6 +373,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 3.2.0 | 2026-02-26 | DataGrid column sizing modes (Fill, FitHeader), zero-warning build, IL2026/IL3050 AOT fixes, theme change responsiveness |
 | 3.1.0 | 2026-02-26 | SelectedIndex/SelectedIndices features, AOT/trimming fixes, DataGrid virtualization crash fix, ComboBox selection fixes |
 | 3.0.0 | 2026-02-25 | AOT/trimming safety for all controls, Func-based property accessors, PropertyMetadataRegistry (#232, #233) |
 | 2.1.8 | 2026-02-24 | DataGrid theme-reactive headers, pagination layout, picker centering, cell text colors (#231) |

--- a/src/MauiControlsExtras/MauiControlsExtras.csproj
+++ b/src/MauiControlsExtras/MauiControlsExtras.csproj
@@ -22,7 +22,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>StefK.MauiControlsExtras</PackageId>
-		<Version>3.1.1</Version>
+		<Version>3.2.0</Version>
 		<Authors>stef-k</Authors>
 		<Company>stef-k</Company>
 		<Product>MAUI Controls Extras</Product>


### PR DESCRIPTION
## Summary

- Bump version to `3.2.0`
- Move `[Unreleased]` entries to `[3.2.0] - 2026-02-26` in CHANGELOG
- Add version history table entry

### What's in 3.2.0

**Added:**
- DataGrid column sizing modes (`Fill`, `FitHeader`, `Auto`, `Fixed`)

**Fixed:**
- Zero-warning Release build (XC0025, CsWinRT1030, IL3050, CS1574)
- IL2026 trim warnings from Binding constructor
- DataGrid StackOverflow crash with Fill column sizing on WinUI
- Theme change responsiveness for all controls

## Test plan

- [x] `dotnet pack -c Release` — produces `StefK.MauiControlsExtras.3.2.0.nupkg`
- [x] `dotnet test` — all 521 tests pass
- [x] 0 warnings, 0 errors