### PR TITLE
fix(ComboBox): replace StyleId marker with ConditionalWeakTable (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **ComboBox**: Fix popup appearing on the first ComboBox when a second instance is clicked — overlay now always uses a dedicated wrapper Grid so it covers the full page regardless of the original layout type (StackLayout, Grid with RowDefinitions, etc.) (#267)
+- **ComboBox**: Replace `StyleId`-based wrapper detection with `ConditionalWeakTable` for cleaner page-wrapper tracking in `PopupOverlayHelper` (#267)
 
 ## [3.2.0] - 2026-02-26
 


### PR DESCRIPTION
## Summary

- Replaces the `StyleId`-based wrapper detection in `PopupOverlayHelper.EnsureRootLayout` with a `ConditionalWeakTable<ContentPage, Grid>` cache, avoiding pollution of the public `StyleId` property
- Adds stale-wrapper detection via content reference equality check (handles cases where page content is replaced between calls)
- Documents intentional wrapper persistence in `<remarks>` XML doc (re-entrant `SizeChanged` safety, Android race conditions, layout neutrality, auto-cleanup via weak references)

Resolves review findings from #269.

## Test plan

- [x] `dotnet build -c Release` — zero warnings
- [x] `dotnet test` — all 521 tests pass
- [ ] Manual: open ComboBox popup on page with multiple ComboBoxes — overlay anchors to correct instance
- [ ] Manual: rotate device / resize window while popup open — popup dismisses cleanly
- [ ] Manual: rapid open/close sequences — no "child already has a parent" crash