### PR TITLE
chore: release v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-03-01
+
 ### Fixed
 
 - **DataGrid**: Fix context menu not showing on Android long-press — use per-cell native `LongClick` handlers instead of grid-level handlers, which were blocked by `TapGestureRecognizer` consuming `ACTION_DOWN` ([#275](https://github.com/stef-k/MauiControlsExtras/issues/275))

--- a/src/MauiControlsExtras/MauiControlsExtras.csproj
+++ b/src/MauiControlsExtras/MauiControlsExtras.csproj
@@ -22,7 +22,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>StefK.MauiControlsExtras</PackageId>
-		<Version>3.3.0</Version>
+		<Version>3.3.1</Version>
 		<Authors>stef-k</Authors>
 		<Company>stef-k</Company>
 		<Product>MAUI Controls Extras</Product>


### PR DESCRIPTION
## Summary

- Bump version to 3.3.1
- Finalize changelog for release

### What's in this release

#### Fixed
- **DataGrid**: Fix context menu not showing on Android long-press (#275)