### PR TITLE
chore: release v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.2] - 2026-03-01
+
 ### Fixed
 
 - **DataGrid:** Android long-press context menu not firing when cells have TapGestureRecognizer — MAUI's gesture system prevents native LongClick detection; replaced with Touch-event-based long-press detection using `Handler.PostDelayed` ([#275](https://github.com/stef-k/MauiControlsExtras/issues/275))

--- a/src/MauiControlsExtras/MauiControlsExtras.csproj
+++ b/src/MauiControlsExtras/MauiControlsExtras.csproj
@@ -22,7 +22,7 @@
 
 		<!-- NuGet Package Metadata -->
 		<PackageId>StefK.MauiControlsExtras</PackageId>
-		<Version>3.3.1</Version>
+		<Version>3.3.2</Version>
 		<Authors>stef-k</Authors>
 		<Company>stef-k</Company>
 		<Product>MAUI Controls Extras</Product>


### PR DESCRIPTION
## Summary

- Bump version to 3.3.2
- Move [Unreleased] changelog entry to [3.3.2] section

Patch release for the Android long-press context menu fix (#275, #278).